### PR TITLE
feat: temporary TabletForceRepair console command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,7 +427,7 @@ Type `tablet` in the developer console (`~` key) for the full list:
 | `TabletSetNotifications true\|false` | Toggle notifications |
 | `TabletSetStartupApp 1\|2\|3\|4` | Set default startup app |
 | `TabletResetSettings` | Reset all settings to defaults |
-| `TabletForceRepair [fee]` | Force repair the tablet (temporary, charges money until the repair station ships) |
+| `TabletForceRepair` | Force repair the tablet for a fixed 3000 fee (temporary until the repair station ships) |
 
 > `TabletApp` appears in the `tablet` help text printout but is **not a registered command** — do not reference it as working.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,6 +427,7 @@ Type `tablet` in the developer console (`~` key) for the full list:
 | `TabletSetNotifications true\|false` | Toggle notifications |
 | `TabletSetStartupApp 1\|2\|3\|4` | Set default startup app |
 | `TabletResetSettings` | Reset all settings to defaults |
+| `TabletForceRepair [fee]` | Force repair the tablet (temporary, charges money until the repair station ships) |
 
 > `TabletApp` appears in the `tablet` help text printout but is **not a registered command** — do not reference it as working.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
-- [~] TEMPORARY `TabletForceRepair` console command: force-completes a display repair for a fee until the real repair station ships, then it is removed.
+- [~] TEMPORARY `TabletForceRepair` console command: force-completes a display repair for a fixed 3000 fee until the real repair station ships, then it is removed.
 - [ ] Focus state fix (Point 1): make goHome / openTablet / unlock pass nil instead of the previous appId (three one-line changes in FarmTabletUI.lua).
 - [x] Keep the ecosystem-map current: MarketDynamicsApp and RandomWorldEventsApp are NOT stubs (source files exist; autoDetect registers them when the handles are present).
 - [x] 2026-07-26 bug sweep: FT-001 (camera rotation restore), FT-002 (nil guard on g_currentMission), FT-003/FT-004/FT-005 fixed and merged to main.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [~] TEMPORARY `TabletForceRepair` console command: force-completes a display repair for a fee until the real repair station ships, then it is removed.
 - [ ] Focus state fix (Point 1): make goHome / openTablet / unlock pass nil instead of the previous appId (three one-line changes in FarmTabletUI.lua).
 - [x] Keep the ecosystem-map current: MarketDynamicsApp and RandomWorldEventsApp are NOT stubs (source files exist; autoDetect registers them when the handles are present).
 - [x] 2026-07-26 bug sweep: FT-001 (camera rotation restore), FT-002 (nil guard on g_currentMission), FT-003/FT-004/FT-005 fixed and merged to main.

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 - [x] FT-003 / FT-004 / FT-005: additional FarmTablet bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
-- [~] TabletForceRepair console command (TEMPORARY): force-completes a display repair for a fee so the player can use the tablet again. To be removed and replaced by the real repair station when it ships.
+- [~] TabletForceRepair console command (TEMPORARY): force-completes a display repair for a fixed 3000 fee so the player can use the tablet again. To be removed and replaced by the real repair station when it ships.
 - [x] Irrigation Suite app (FT #100): a read-only SCS operating picture (coverage overlay + system status), built to Wizard's UI brief and merged; real frame-cache for the coverage overlay (03a6198).
 - [x] Rotation Planner app (FT #99): reads SoilFertilizer's #739 rotation data surface (lastCrop3 + bonus countdown), prefers the SF-blessed candidate pool.
 - [x] Soil tablet field-card redesign (FT #101): the Soil app field cards reworked per Tyson's approval.

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - [x] FT-003 / FT-004 / FT-005: additional FarmTablet bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
+- [~] TabletForceRepair console command (TEMPORARY): force-completes a display repair for a fee so the player can use the tablet again. To be removed and replaced by the real repair station when it ships.
 - [x] Irrigation Suite app (FT #100): a read-only SCS operating picture (coverage overlay + system status), built to Wizard's UI brief and merged; real frame-cache for the coverage overlay (03a6198).
 - [x] Rotation Planner app (FT #99): reads SoilFertilizer's #739 rotation data surface (lastCrop3 + bonus countdown), prefers the SF-blessed candidate pool.
 - [x] Soil tablet field-card redesign (FT #101): the Soil app field cards reworked per Tyson's approval.

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -1938,6 +1938,54 @@ function FarmTabletUI:_updateTabletRepairSystem(dt, force)
     return false
 end
 
+-- TEMPORARY console command helper until the real repair station ships.
+-- Instantly finishes an in-progress display repair so the tablet is usable again.
+-- Charges the farm a fixed fee, then clears the repair state exactly like a
+-- natural completion does (see _updateTabletRepairSystem). Remove this together
+-- with the TabletForceRepair console command once the repair station exists.
+function FarmTabletUI:forceCompleteRepair(fee)
+    if self._tabletRepairActive ~= true then
+        return false, "Tablet is not in repair, nothing to force"
+    end
+    fee = math.max(0, math.floor(tonumber(fee) or 0))
+    if fee > 0 then
+        if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
+            return false, "Money can only be deducted on the server"
+        end
+        if g_farmManager == nil then
+            return false, "Farm manager not available"
+        end
+        local farmId = self:_getNetworkBillingFarmId()
+        local ok = pcall(function()
+            local farm = g_farmManager:getFarmById(farmId)
+            if farm ~= nil and farm.changeBalance ~= nil then
+                farm:changeBalance(-fee, MoneyType.OTHER)
+                if g_currentMission.addMoneyChange ~= nil then
+                    g_currentMission:addMoneyChange(-fee, farmId, MoneyType.OTHER, true)
+                end
+            end
+        end)
+        if not ok then
+            return false, "Could not deduct the repair fee"
+        end
+    end
+    self._tabletRepairActive = false
+    self._tabletRepairStartMin = nil
+    self._tabletRepairEndMin = nil
+    self._tabletRepairNotifiedDone = true
+    self:_saveSignalProviderSelection({ id = self._signalProviderId or "realistic_farming", name = self._signalProvider or "Realistic Farming Mobile" })
+    self:_resetTabletRepairUseTimer()
+    if self.uiState == "repair" then
+        self.uiState = (self.settings.lockScreenEnabled ~= false) and "lock" or "home"
+    end
+    if fee > 0 then
+        self:_notifyTabletRepair(ftUiFormat("ft_repair_force_done_msg", "Forced repair complete. Repair fee charged: %d.", fee))
+    else
+        self:_notifyTabletRepair(ftUiText("ft_repair_done_msg", "Repair completed. Tablet is ready to use again."))
+    end
+    return true, string.format("Forced repair complete. Repair fee charged: %d.", fee)
+end
+
 function FarmTabletUI:_drawRepairScreen()
     local L = FT.LAYOUT
     local r = self.r

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -1940,7 +1940,7 @@ end
 
 -- TEMPORARY console command helper until the real repair station ships.
 -- Instantly finishes an in-progress display repair so the tablet is usable again.
--- Charges the farm a fixed fee (FT_FORCE_REPAIR_FEE), then clears the repair state
+-- Charges the farm a fixed fee (FT.FORCE_REPAIR_FEE), then clears the repair state
 -- exactly like a natural completion does (see _updateTabletRepairSystem). Remove
 -- this together with the TabletForceRepair console command once the repair
 -- station exists.

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -1940,34 +1940,33 @@ end
 
 -- TEMPORARY console command helper until the real repair station ships.
 -- Instantly finishes an in-progress display repair so the tablet is usable again.
--- Charges the farm a fixed fee, then clears the repair state exactly like a
--- natural completion does (see _updateTabletRepairSystem). Remove this together
--- with the TabletForceRepair console command once the repair station exists.
-function FarmTabletUI:forceCompleteRepair(fee)
+-- Charges the farm a fixed fee (FT_FORCE_REPAIR_FEE), then clears the repair state
+-- exactly like a natural completion does (see _updateTabletRepairSystem). Remove
+-- this together with the TabletForceRepair console command once the repair
+-- station exists.
+function FarmTabletUI:forceCompleteRepair()
     if self._tabletRepairActive ~= true then
         return false, "Tablet is not in repair, nothing to force"
     end
-    fee = math.max(0, math.floor(tonumber(fee) or 0))
-    if fee > 0 then
-        if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
-            return false, "Money can only be deducted on the server"
-        end
-        if g_farmManager == nil then
-            return false, "Farm manager not available"
-        end
-        local farmId = self:_getNetworkBillingFarmId()
-        local ok = pcall(function()
-            local farm = g_farmManager:getFarmById(farmId)
-            if farm ~= nil and farm.changeBalance ~= nil then
-                farm:changeBalance(-fee, MoneyType.OTHER)
-                if g_currentMission.addMoneyChange ~= nil then
-                    g_currentMission:addMoneyChange(-fee, farmId, MoneyType.OTHER, true)
-                end
+    local fee = FT.FORCE_REPAIR_FEE
+    if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
+        return false, "Money can only be deducted on the server"
+    end
+    if g_farmManager == nil then
+        return false, "Farm manager not available"
+    end
+    local farmId = self:_getNetworkBillingFarmId()
+    local ok = pcall(function()
+        local farm = g_farmManager:getFarmById(farmId)
+        if farm ~= nil and farm.changeBalance ~= nil then
+            farm:changeBalance(-fee, MoneyType.OTHER)
+            if g_currentMission.addMoneyChange ~= nil then
+                g_currentMission:addMoneyChange(-fee, farmId, MoneyType.OTHER, true)
             end
-        end)
-        if not ok then
-            return false, "Could not deduct the repair fee"
         end
+    end)
+    if not ok then
+        return false, "Could not deduct the repair fee"
     end
     self._tabletRepairActive = false
     self._tabletRepairStartMin = nil
@@ -1978,11 +1977,7 @@ function FarmTabletUI:forceCompleteRepair(fee)
     if self.uiState == "repair" then
         self.uiState = (self.settings.lockScreenEnabled ~= false) and "lock" or "home"
     end
-    if fee > 0 then
-        self:_notifyTabletRepair(ftUiFormat("ft_repair_force_done_msg", "Forced repair complete. Repair fee charged: %d.", fee))
-    else
-        self:_notifyTabletRepair(ftUiText("ft_repair_done_msg", "Repair completed. Tablet is ready to use again."))
-    end
+    self:_notifyTabletRepair(ftUiFormat("ft_repair_force_done_msg", "Forced repair complete. Repair fee charged: %d.", fee))
     return true, string.format("Forced repair complete. Repair fee charged: %d.", fee)
 end
 

--- a/src/core/Constants.lua
+++ b/src/core/Constants.lua
@@ -6,6 +6,9 @@ FT = FT or {}
 
 FT.VERSION = "2.5.3.0"   -- keep in sync with modDesc.xml <version>; shown in the tablet UI
 
+-- TEMPORARY console command fee until the real repair station ships.
+FT.FORCE_REPAIR_FEE = 3000
+
 -- Generic localization helpers.  This keeps old app scripts from drawing
 -- fixed English labels directly on screen: if a visible text has a matching
 -- translation key, the renderer swaps it before drawing.

--- a/src/settings/SettingsGUI.lua
+++ b/src/settings/SettingsGUI.lua
@@ -26,7 +26,7 @@ function SettingsGUI:registerConsoleCommands()
     addConsoleCommand("TabletShowSettings", "Show current settings", "consoleCommandTabletShowSettings", self)
     addConsoleCommand("TabletResetSettings", "Reset all settings to defaults", "consoleCommandTabletResetSettings", self)
     -- TEMPORARY: force repair the tablet until the real repair station ships.
-    addConsoleCommand("TabletForceRepair", "Force repair the tablet (temporary, charges money)", "consoleCommandTabletForceRepair", self)
+    addConsoleCommand("TabletForceRepair", "Force repair the tablet (temporary, charges 3000)", "consoleCommandTabletForceRepair", self)
     
     addConsoleCommand("tablet", "Show all tablet commands", "consoleCommandHelp", self)
     
@@ -61,7 +61,7 @@ function SettingsGUI:consoleCommandHelp()
            "TabletApp [id] - Switch to app immediately\n" ..
            "TabletShowSettings - Show current settings\n" ..
            "TabletResetSettings - Reset to defaults\n" ..
-           "TabletForceRepair [fee] - Force repair tablet (temporary, charges money)\n" ..
+           "TabletForceRepair - Force repair tablet (temporary, charges 3000)\n" ..
            "==================================="
 end
 
@@ -190,11 +190,11 @@ function SettingsGUI:consoleCommandTabletResetSettings()
     return "Error: Farm Tablet not initialized"
 end
 
-function SettingsGUI:consoleCommandTabletForceRepair(fee)
+function SettingsGUI:consoleCommandTabletForceRepair()
     if g_FarmTablet == nil or g_FarmTablet.ui == nil then
         return "Error: Farm Tablet not initialized"
     end
-    local ok, msg = g_FarmTablet.ui:forceCompleteRepair(fee)
+    local ok, msg = g_FarmTablet.ui:forceCompleteRepair()
     if ok then
         return msg
     end

--- a/src/settings/SettingsGUI.lua
+++ b/src/settings/SettingsGUI.lua
@@ -25,6 +25,8 @@ function SettingsGUI:registerConsoleCommands()
     addConsoleCommand("TabletApp", "Switch to app by ID", "consoleCommandTabletApp", self)
     addConsoleCommand("TabletShowSettings", "Show current settings", "consoleCommandTabletShowSettings", self)
     addConsoleCommand("TabletResetSettings", "Reset all settings to defaults", "consoleCommandTabletResetSettings", self)
+    -- TEMPORARY: force repair the tablet until the real repair station ships.
+    addConsoleCommand("TabletForceRepair", "Force repair the tablet (temporary, charges money)", "consoleCommandTabletForceRepair", self)
     
     addConsoleCommand("tablet", "Show all tablet commands", "consoleCommandHelp", self)
     
@@ -43,6 +45,7 @@ function SettingsGUI:unregisterConsoleCommands()
     removeConsoleCommand("TabletApp")
     removeConsoleCommand("TabletShowSettings")
     removeConsoleCommand("TabletResetSettings")
+    removeConsoleCommand("TabletForceRepair")
     removeConsoleCommand("tablet")
 end
 
@@ -58,6 +61,7 @@ function SettingsGUI:consoleCommandHelp()
            "TabletApp [id] - Switch to app immediately\n" ..
            "TabletShowSettings - Show current settings\n" ..
            "TabletResetSettings - Reset to defaults\n" ..
+           "TabletForceRepair [fee] - Force repair tablet (temporary, charges money)\n" ..
            "==================================="
 end
 
@@ -184,4 +188,15 @@ function SettingsGUI:consoleCommandTabletResetSettings()
     end
     
     return "Error: Farm Tablet not initialized"
+end
+
+function SettingsGUI:consoleCommandTabletForceRepair(fee)
+    if g_FarmTablet == nil or g_FarmTablet.ui == nil then
+        return "Error: Farm Tablet not initialized"
+    end
+    local ok, msg = g_FarmTablet.ui:forceCompleteRepair(fee)
+    if ok then
+        return msg
+    end
+    return "Error: " .. tostring(msg or "could not force repair the tablet")
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -307,6 +307,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet-Service" />
         <text name="ft_repair_started_msg" text="Tablet in Reparatur." />
         <text name="ft_repair_done_msg" text="Tablet wieder einsatzbereit." />
+        <text name="ft_repair_force_done_msg" text="Erzwungene Reparatur abgeschlossen. Reparaturgebuehr berechnet: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in Reparatur. Wir melden uns." />
         <text name="ft_repair_title" text="DISPLAYSCHADEN" />
         <text name="ft_repair_subtitle" text="Displayschaden durch einen Sturz." />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -308,6 +308,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -307,6 +307,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -307,6 +307,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -307,6 +307,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -307,6 +307,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -306,6 +306,7 @@
         <text name="ft_repair_service_title" text="Tablet Service" />
         <text name="ft_repair_started_msg" text="Display damage from a drop. Tablet is being repaired." />
         <text name="ft_repair_done_msg" text="Repair completed. Tablet is ready to use again." />
+        <text name="ft_repair_force_done_msg" text="Forced repair complete. Repair fee charged: %d." />
         <text name="ft_repair_open_blocked_msg" text="Tablet in repair. We will notify you when it is delivered again." />
         <text name="ft_repair_title" text="DISPLAY DAMAGE" />
         <text name="ft_repair_subtitle" text="Display damage from a drop" />


### PR DESCRIPTION
# Temporary TabletForceRepair console command

Adds a `TabletForceRepair` console command that force-completes an
in-progress tablet display repair so the player can use the tablet again.
It charges the farm a fixed fee of 3000 (`FT.FORCE_REPAIR_FEE`), shows an
in-game notification on completion, and returns a console confirmation.

**This is a TEMPORARY stopgap until the real tablet repair station ships.**
The command in `src/settings/SettingsGUI.lua` and `forceCompleteRepair()` in
`src/FarmTabletUI.lua` are meant to be removed and replaced by the repair
station. Tracked in `TODO.md` and `ROADMAP.md`.

## Changes
- `FarmTabletUI:forceCompleteRepair()`: clears the display repair state
  exactly like a natural completion, persists provider settings, deducts the
  fixed 3000 fee server-side via `farm:changeBalance`, and notifies the player.
- `TabletForceRepair` console command registered/unregistered in
  `SettingsGUI.lua` and listed in `tablet` help.
- New `ft_repair_force_done_msg` translation string in all 26 languages.
- Docs: `CLAUDE.md` console table, `TODO.md`, `ROADMAP.md`.

Not yet tested in game. Built and deployed; Lua 5.1 syntax verified via the
pre-commit luaparse gate.
