### PR TITLE
feat(ft): organic app compost display wired to CompostManager

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-29 (updated 2026-07-25)
 
 ## Near-term (next release cycle)
+- [x] Organic app compost display (OM-201, 2026-08-18): the COMPOST section of the Organic app now shows live compost batch state from SoilFertilizer's CompostManager (`g_currentMission.compostManager:getBatchRows`): batch id, days remaining or READY + output litres, and the organic-safe tag. Read-only; starting/collecting stays on the SF console commands. Replaces the "waiting on compost production API" stub.
 - [~] TEMPORARY `TabletForceRepair` console command: force-completes a display repair for a fixed 3000 fee until the real repair station ships, then it is removed.
 - [ ] Focus state fix (Point 1): make goHome / openTablet / unlock pass nil instead of the previous appId (three one-line changes in FarmTabletUI.lua).
 - [x] Keep the ecosystem-map current: MarketDynamicsApp and RandomWorldEventsApp are NOT stubs (source files exist; autoDetect registers them when the handles are present).

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - [x] FT-003 / FT-004 / FT-005: additional FarmTablet bugs fixed in 2026-07-26 bug sweep, merged to main.
 
 ## Features / enhancements
+- [x] Organic app compost display (OM-201, 2026-08-18): the COMPOST stub in `OrganicApp` now renders live batch rows from SF's `CompostManager` (`getBatchRows`), with READY/remaining days, output litres and the organic-safe tag. Requires the SF cross-mod handle (`mission.compostManager`, PR alongside). Read-only display.
 - [~] TabletForceRepair console command (TEMPORARY): force-completes a display repair for a fixed 3000 fee so the player can use the tablet again. To be removed and replaced by the real repair station when it ships.
 - [x] Irrigation Suite app (FT #100): a read-only SCS operating picture (coverage overlay + system status), built to Wizard's UI brief and merged; real frame-cache for the coverage overlay (03a6198).
 - [x] Rotation Planner app (FT #99): reads SoilFertilizer's #739 rotation data surface (lastCrop3 + bonus countdown), prefers the SF-blessed candidate pool.

--- a/src/apps/OrganicApp.lua
+++ b/src/apps/OrganicApp.lua
@@ -2,7 +2,7 @@
 -- FarmTablet - Organic Management (Arissani brief)
 -- =========================================================
 -- Read-only hub over Soil Fertilizer organic certification.
--- CERTIFICATION + PRACTICES build now; COMPOST / LIVESTOCK / MARKET stub.
+-- CERTIFICATION + PRACTICES + COMPOST display built; LIVESTOCK / MARKET stub.
 -- Opt-in / opt-out via SF requestOptIn / requestOptOut only.
 -- =========================================================
 
@@ -252,10 +252,31 @@ FarmTabletUI:registerDrawer(FT.APP.ORGANIC, function(self)
     ------------------------------------------------------------------
     y = self:drawRule(y, 0.3)
     y = self:drawSection(y, "COMPOST")
-    self.r:appText(x, y - FT.py(4), FT.FONT.SMALL,
-        "not available - waiting on compost production API",
-        RenderText.ALIGN_LEFT, FT.C.MUTED)
-    y = y - FT.py(22)
+    local compost = (g_currentMission ~= nil and g_currentMission.compostManager) or nil
+    if compost == nil or type(compost.getBatchRows) ~= "function" then
+        self.r:appText(x, y - FT.py(4), FT.FONT.SMALL,
+            "not available - install SoilFertilizer", RenderText.ALIGN_LEFT, FT.C.MUTED)
+        y = y - FT.py(22)
+    else
+        local rows = _pcall(function() return compost:getBatchRows(farmId) end) or {}
+        if #rows == 0 then
+            self.r:appText(x, y - FT.py(4), FT.FONT.SMALL,
+                "No compost batches. Start one from the SoilFertilizer console.",
+                RenderText.ALIGN_LEFT, FT.C.MUTED)
+        else
+            for _, b in ipairs(rows) do
+                local state = b.ready
+                    and string.format("READY - %d L", math.floor(b.outputLitres or 0))
+                    or  string.format("%d day(s) left", math.floor(b.daysRemaining or 0))
+                local tag = b.organicSafe and "organic-safe" or "not organic-safe"
+                self.r:appText(x, y - FT.py(2), FT.FONT.TINY,
+                    string.format("Batch #%d: %s  (%s)", b.batchId, state, tag),
+                    RenderText.ALIGN_LEFT, b.ready and FT.C.POSITIVE or FT.C.TEXT_DIM)
+                y = y - FT.py(14)
+            end
+        end
+        y = y - FT.py(8)
+    end
 
     y = self:drawSection(y, "LIVESTOCK")
     self.r:appText(x, y - FT.py(4), FT.FONT.SMALL,


### PR DESCRIPTION
Wires the Organic app's COMPOST section (was a stub) to SoilFertilizer's CompostManager via the mission handle: batch id, days remaining or READY + output litres, and the organic-safe tag. Read-only; start/collect stays on the SF console commands. Pairs with the SF mission.compostManager publish PR.