### PR TITLE
fix(ft): register FarmTabletForceRepairEvent with InitEventClass

### DIFF
--- a/src/events/FarmTabletForceRepairEvent.lua
+++ b/src/events/FarmTabletForceRepairEvent.lua
@@ -13,6 +13,8 @@
 FarmTabletForceRepairEvent = {}
 local FarmTabletForceRepairEvent_mt = Class(FarmTabletForceRepairEvent, Event)
 
+InitEventClass(FarmTabletForceRepairEvent, "FarmTabletForceRepairEvent")
+
 function FarmTabletForceRepairEvent.emptyNew()
     local self = Event.new(FarmTabletForceRepairEvent_mt)
     return self


### PR DESCRIPTION
The InitEventClass call from #134 was pushed after that PR merged, so development never received it and the client throws 'Invalid event id' when sending the repair request. This adds the registration line so the engine can map the class to an event id.