### PR TITLE
build: fail on Lua 5.1 syntax errors before building the zip

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 import zipfile
 import os
+import subprocess
 import sys
 import shutil
 from pathlib import Path
@@ -21,6 +22,40 @@ MODS_DIR = Path.home() / "Documents" / "My Games" / "FarmingSimulator2025" / "mo
 EXCLUDE_DIRS = {".git", ".claude", ".github", "__MACOSX", "tools", ".vscode"}
 EXCLUDE_EXTS = {".sh", ".py", ".md", ".DS_Store", ".zip"}
 EXCLUDE_FILES = {".gitignore", "icon_source.png"}
+
+def lua_files():
+    """Yield every .lua file that will ship in the zip, using the same exclusions
+    as build_zip(). The entry point main.lua lives at the repo root, not under
+    src/, so this walks the whole mod tree rather than a single source dir."""
+    for root, dirs, files in os.walk(MOD_DIR):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for fname in files:
+            if fname in EXCLUDE_FILES:
+                continue
+            if any(fname.endswith(ext) for ext in EXCLUDE_EXTS):
+                continue
+            if fname.endswith(".lua"):
+                yield Path(root) / fname
+
+def check_lua_syntax():
+    """Fail the build if any shipping .lua file will not parse under Lua 5.1.
+
+    FS25 runs Lua 5.1. A parse error silently drops the whole file at load, so a
+    bad file would ship as a missing feature with nothing but a compiler line
+    nobody reads. This surfaces the error here, before the zip is built."""
+    files = list(lua_files())
+    if not files:
+        return
+    checker = MOD_DIR / "tools" / "test" / "syntax-check.mjs"
+    if not checker.exists():
+        print("  WARNING: tools/test/syntax-check.mjs not found; skipping Lua 5.1 gate")
+        return
+    node_modules = MOD_DIR / "tools" / "test" / "node_modules"
+    if not node_modules.exists():
+        print("  Installing tools/test dependencies (luaparse)...")
+        subprocess.run(["npm", "install", "--silent"], cwd=checker.parent, check=True)
+    print("  Checking Lua 5.1 syntax...")
+    subprocess.run(["node", str(checker), *[str(p) for p in files]], check=True)
 
 def build_zip():
     print(f"============================================")
@@ -62,6 +97,7 @@ def deploy():
     print(f"  Deployed: {dest}")
 
 if __name__ == "__main__":
+    check_lua_syntax()
     build_zip()
     if "--deploy" in sys.argv:
         deploy()

--- a/tools/test/syntax-check.mjs
+++ b/tools/test/syntax-check.mjs
@@ -1,0 +1,51 @@
+// Lua 5.1 syntax checker for FS25_FarmTablet, driven by build.py.
+//
+// FS25 runs Lua 5.1. A parse error (or a 5.2+-only construct like `goto`/`::label::`)
+// makes the whole mod fail to load in-game with no useful message: the file is
+// silently dropped, so one feature is simply absent. This parses every Lua file the
+// build ships with luaparse pinned to luaVersion "5.1", so those errors surface here
+// in <1s instead of after a deploy + game restart.
+//
+// Usage:  node syntax-check.mjs <abs-path>...
+// Exit:   0 = all files parse, 1 = at least one parse error.
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+
+const files = process.argv.slice(2);
+let bad = 0;
+
+for (const f of files) {
+  let code;
+  try {
+    code = readFileSync(f, "utf8");
+  } catch {
+    continue; // deleted or moved between collection and now; nothing to parse
+  }
+
+  // A UTF-8 BOM is caught by the parse below, but only as
+  // "Cannot read properties of undefined (reading 'range')", which tells you
+  // nothing. Name it explicitly instead. Lua does not skip a byte order mark
+  // the way it skips a shebang, so U+FEFF is read as part of the first token.
+  if (code.charCodeAt(0) === 0xfeff) {
+    bad++;
+    console.error(`  \u2717 ${f}`);
+    console.error("      Starts with a UTF-8 BOM (EF BB BF). Lua 5.1 cannot parse it.");
+    console.error("      Fix: re-save as UTF-8 WITHOUT BOM, or strip the 3 leading bytes.");
+    continue;
+  }
+
+  try {
+    luaparse.parse(code, { luaVersion: "5.1", comments: false, locations: true });
+  } catch (e) {
+    bad++;
+    console.error(`  \u2717 ${f}\n      ${e.message}`);
+  }
+}
+
+if (bad > 0) {
+  console.error(`\n  ${bad} Lua file(s) will NOT compile in FS25. Build blocked.`);
+  console.error("  FS25 drops the whole file at load with no useful message, so this");
+  console.error("  would ship as a silently missing feature. Fix before building.");
+  process.exit(1);
+}
+console.log(`  \u2713 Lua 5.1 syntax OK - ${files.length} file(s)`);


### PR DESCRIPTION
## What

\uild.py\ had no Lua 5.1 syntax gate. A parse error in one app file silently drops that file at load in FS25, so a bad file could ship as a missing feature with nothing but a compiler line nobody reads. The pre-commit hook catches staged files, but a deploy that bypasses the hook (or a file added after staging) could still ship broken.

## Change

- Add \check_lua_syntax()\ to \uild.py\, run before the zip is built. It walks the mod tree with the same exclusions as \uild_zip()\ (so it covers \main.lua\ at the repo root, not just \src/\) and parses every shipping \.lua\ file with luaparse pinned to Lua 5.1.
- Add \	ools/test/syntax-check.mjs\, a path-driven Lua 5.1 checker with build-appropriate messaging (mirrors the suite's existing \check-staged.mjs\ but takes explicit file paths and reports \Build blocked\).

## Verification

- Clean tree: \py build.py\ reports \Lua 5.1 syntax OK - 67 file(s)\ and builds normally.
- Injected a bad file (\local x =\): the gate reports the error and blocks the build (exit non-zero) before the zip is created.
- No em dashes in shipped prose.