### PR TITLE
fix: weather dial reports a refusal instead of doing nothing (#140)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,3 +36,7 @@
 
 ## Deferred / parked
 - Pocket Profile: filed post-rollout, evaluate after WorkerCosts is stable.
+
+
+## 2026-08-31 (Fred): weather dial refusal made visible (issue #140)
+- [x] The World Weather chips no longer swallow the WeatherGuard result. A refused or errored change now draws a notice above the dial instead of silently doing nothing (admin-only wording for non-admins, WeatherGuard-refused wording otherwise). In-game verification pending.

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@
 > Convention: `[ ]` open · `[~]` in progress · `[x]` done · `[!]` blocked. Newest at the top of each section.
 
 ## Bugs
+- [x] 2026-08-31: **Weather dial refusal now visible (issue #140).** The World Weather chips called `WeatherGuard:requestWeatherMode` inside a bare `pcall` and discarded the result, so on a dedicated server a refused or errored change looked like "nothing happened" with no message. The chip handler now captures the return, clears any stale notice on success, and on failure draws a notice line above the dial: admin-only wording when the player is not a host or master user, WeatherGuard-refused wording otherwise. In-game verification pending.
+
 - [x] 2026-07-30: `src/apps/ProStaffApp.lua:111` failed to COMPILE - `...` referenced from inside an anonymous function ("cannot use '...' outside of a vararg function"). Lua 5.1 does not let a nested closure see the enclosing function's vararg. The whole file was rejected, so the ProStaff app was dead in every session. `safeGet` now passes the varargs straight to `pcall` (no inner closure) and guards a missing method.
 - [ ] **ROOT CAUSE, still open: `build.py` has NO Lua 5.1 syntax gate**, which is the only reason the above reached the game. SoilFertilizer catches this class of error before it can ship (its pre-commit hook runs `luaparse` pinned to 5.1 over every source file, plus a lint pass). Port that gate here: either a `tools/test/` harness of our own, or a syntax step in `build.py` that fails the build. A compile error in one app file takes the file down silently, so this is worth more than any individual fix.
 

--- a/src/apps/WeatherApp.lua
+++ b/src/apps/WeatherApp.lua
@@ -34,6 +34,14 @@ local function _wg()
     return g_currentMission and g_currentMission.weatherGuard or nil
 end
 
+-- Whether this player is allowed to change the shared world weather. The host is
+-- always (SP / listen server the hosting client IS the server on FS25); a
+-- dedicated-server client can only when logged in as a server admin (master user).
+local function _canSetWorldWeather()
+    return g_currentMission ~= nil
+        and (g_currentMission:getIsServer() or g_currentMission.isMasterUser == true)
+end
+
 FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     local AC = FT.appColor(FT.APP.WEATHER)
 
@@ -92,6 +100,17 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
     end
     y = y - FT.py(24)
 
+    -- Weather-mode change feedback (#140). Shown when the last chip press was
+    -- refused (non-admin on a dedicated server, or WeatherGuard refused/errored)
+    -- so the player is never left with a silent "nothing happened".
+    if self._weatherModeNotice then
+        self.r:appRect(x - FT.px(4), y - FT.py(18), cw + FT.px(8), FT.py(16),
+            { 0.55, 0.20, 0.14, 0.90 })
+        self.r:appText(x, y - FT.py(14), FT.FONT.SMALL,
+            self._weatherModeNotice, RenderText.ALIGN_LEFT, FT.C.NEGATIVE)
+        y = y - FT.py(24)
+    end
+
     -- World Weather dial (WeatherGuard only)
     local wg = _wg()
     if wg ~= nil and type(wg.requestWeatherMode) == "function" then
@@ -117,7 +136,18 @@ FarmTabletUI:registerDrawer(FT.APP.WEATHER, function(self)
             local btn = self.r:button(cx, y - chipH, chipW, chipH, "",
                 { 0, 0, 0, 0.01 },
                 { onClick = function()
-                    pcall(function() wg:requestWeatherMode(i) end)
+                    -- Cancel any stale notice, then apply. Do not swallow the result
+                    -- (#140): if WeatherGuard refuses or errors on a dedicated server
+                    -- the player must see why instead of watching nothing happen.
+                    self._weatherModeNotice = nil
+                    local ok, res = pcall(function() return wg:requestWeatherMode(i) end)
+                    if not (ok and res == true) then
+                        if _canSetWorldWeather() then
+                            self._weatherModeNotice = "World weather change was refused by WeatherGuard."
+                        else
+                            self._weatherModeNotice = "World weather is admin-only. Log in as a server admin to change it."
+                        end
+                    end
                     if self.system and self.system.data and self.system.data.invalidate then
                         self.system.data:invalidate()
                     end


### PR DESCRIPTION
Fixed: the tablet's World Weather dial now tells you when a change did not take effect, instead of silently doing nothing.

What: issue #140. On a dedicated server the World Weather chips called `WeatherGuard:requestWeatherMode` inside a bare `pcall` and discarded both the return value and any error. Whether the request succeeded, was refused, or errored, the app invalidated and re-rendered the unchanged mode, so the player saw the same thing every time: nothing happened and no message appeared.

Fix: the chip handler now captures the result. On success it clears any stale notice. On failure it draws a notice line above the dial, with the reason:
- "World weather is admin-only. Log in as a server admin to change it." when the player is neither the host nor a master user.
- "World weather change was refused by WeatherGuard." when the player has the rights but WeatherGuard refused or errored.

WeatherGuard's own request path is untouched. It already routes the change server-authoritatively through its NetworkSync admin action (adminOnly = true), which is correct for a shared-world control; what was missing was the tablet reporting a refusal.

Validated: luaparse Lua 5.1 syntax clean, the repo pre-commit gate passed, build packages clean. In-game verification still pending; this needs a playtest on a dedicated server, both as a non-admin (expect the admin-only notice) and as a logged-in admin (expect the change to apply).