### PR TITLE
Irrigation Suite: rain-key state and hours of water

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK, Akita83</author>
-    <version>2.6.0.6</version>
+    <version>2.6.0.7</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletManager.lua
+++ b/src/FarmTabletManager.lua
@@ -145,6 +145,66 @@ function FarmTabletManager:update(dt)
     if self.inputHandler then self.inputHandler:update(dt) end
     if self.system       then self.system:update(dt)      end
     if self.ui           then self.ui:update(dt)          end
+    self:updateRainKeyEdges(dt)
+end
+
+--- [SCS-046] Notify once when a pivot ENTERS or LEAVES rain pause, and never
+--- for anything else.
+---
+--- The first snapshot seen after a join is stored as a quiet baseline: a player
+--- who joins while a pivot is already paused gets no historical alarm, which is
+--- acceptance point 5. Accumulator progress and dry countdown deliberately do
+--- not notify, because they move continuously and would bury the one edge that
+--- matters. Read-only: this reads the SCS snapshot and writes nothing.
+function FarmTabletManager:updateRainKeyEdges(dt)
+    if not self.settings.showTabletNotifications then return end
+    if self.mission == nil or not self.mission:getIsClient() then return end
+
+    self._rainKeyPollMs = (self._rainKeyPollMs or 0) + (tonumber(dt) or 0)
+    if self._rainKeyPollMs < 1000 then return end
+    self._rainKeyPollMs = 0
+
+    local scs = g_currentMission ~= nil and g_currentMission.cropStressManager or nil
+    if scs == nil or type(scs.getIrrigationSystems) ~= "function" then return end
+    local ok, systems = pcall(function() return scs:getIrrigationSystems() end)
+    if not ok or type(systems) ~= "table" then return end
+
+    local seen = {}
+    local baseline = self._rainKeyPaused == nil
+    self._rainKeyPaused = self._rainKeyPaused or {}
+
+    for _, sys in ipairs(systems) do
+        local id = sys.systemId or sys.id
+        if id ~= nil and sys.activityState ~= nil then
+            local paused = (sys.activityState == "RAIN_PAUSED")
+            seen[id] = true
+            local was = self._rainKeyPaused[id]
+            if not baseline and was ~= nil and was ~= paused then
+                local title = g_i18n ~= nil and g_i18n:hasText("ft_rainKey_notifyTitle")
+                              and g_i18n:getText("ft_rainKey_notifyTitle") or "Irrigation"
+                local msg
+                if paused then
+                    local fmt = g_i18n ~= nil and g_i18n:hasText("ft_rainKey_notifyPaused")
+                                and g_i18n:getText("ft_rainKey_notifyPaused")
+                                or "Pivot #%s stopped because the rain key tripped"
+                    msg = string.format(fmt, tostring(id))
+                else
+                    local fmt = g_i18n ~= nil and g_i18n:hasText("ft_rainKey_notifyResumed")
+                                and g_i18n:getText("ft_rainKey_notifyResumed")
+                                or "Pivot #%s is eligible again at the next schedule check"
+                    msg = string.format(fmt, tostring(id))
+                end
+                self:showNotification(title, msg)
+            end
+            self._rainKeyPaused[id] = paused
+        end
+    end
+
+    -- Drop rows that no longer exist, so a sold pivot cannot fire an edge if a
+    -- later id reuse lands on the opposite state.
+    for id in pairs(self._rainKeyPaused) do
+        if not seen[id] then self._rainKeyPaused[id] = nil end
+    end
 end
 
 function FarmTabletManager:openTablet()

--- a/src/apps/IrrigationSuiteApp.lua
+++ b/src/apps/IrrigationSuiteApp.lua
@@ -25,6 +25,103 @@ local function _scs()
     return g_currentMission and g_currentMission.cropStressManager or nil
 end
 
+-- [SCS-046] Rain-key presentation helpers.
+--
+-- Every meaning below comes from the SCS snapshot and nothing is inferred here:
+-- FarmTablet never reads local sky, schedule or soil to decide rain pause, and
+-- never reaches into irrigationManager.systems. Absence is said out loud rather
+-- than being drawn as a clear, dry or safe reading.
+
+--- Modelled mm is a balance sensor unit, not engine precipitation and not a
+--- soil-moisture percent, so it is always rendered with its own unit word.
+local function _mm(v)
+    local n = tonumber(v)
+    if n == nil then return _T("ft_rainKey_unknown", "unknown") end
+    return string.format("%.1f %s", n, _T("ft_rainKey_mm", "mm modelled"))
+end
+
+--- Game minutes as a short farm phrase. nil means show no countdown at all.
+local function _mins(v)
+    local n = tonumber(v)
+    if n == nil or n < 0 then return nil end
+    if n < 60 then return string.format("%d min", math.floor(n + 0.5)) end
+    return string.format("%.1f h", n / 60)
+end
+
+local RAIN_KEY_STATE_TEXT = {
+    UNFITTED          = { "ft_rainKey_unfitted",     "no rain key fitted" },
+    ARMED             = { "ft_rainKey_armed",        "rain key armed" },
+    COLLECTING        = { "ft_rainKey_collecting",   "collecting rain" },
+    TRIPPED           = { "ft_rainKey_tripped",      "rain key tripped" },
+    INPUT_UNAVAILABLE = { "ft_rainKey_inputUnavail", "sensor input unavailable" },
+}
+
+local PAUSE_REASON_TEXT = {
+    RAIN_KEY_TRIPPED     = { "ft_rainKey_whyTripped",  "stopped because the rain key tripped" },
+    INPUT_UNAVAILABLE    = { "ft_rainKey_whyNoInput",  "cannot read weather" },
+    SOURCE_UNAVAILABLE   = { "ft_rainKey_whyNoSource", "no water source" },
+    PRESSURE_UNAVAILABLE = { "ft_rainKey_whyNoPress",  "no pressure" },
+    SCHEDULE_OFF         = { "ft_rainKey_whySchedule", "outside the schedule" },
+    MASTER_DISABLED      = { "ft_rainKey_whyMaster",   "irrigation master switch off" },
+}
+
+local ACTIVITY_TEXT = {
+    RUNNING     = { "ft_rainKey_running",    "RUNNING" },
+    RAIN_PAUSED = { "ft_rainKey_rainPaused", "RAIN PAUSED" },
+    OFF         = { "ft_rainKey_off",        "off" },
+}
+
+local function _lookup(tbl, code, fallbackKey, fallbackText)
+    local row = code ~= nil and tbl[code] or nil
+    if row ~= nil then return _T(row[1], row[2]) end
+    return _T(fallbackKey, fallbackText)
+end
+
+--- [BUILD 19:44] Irrigation-hours for one water source, in words.
+---
+--- Unlimited is the WORD, never a zero and never a dash: a pump with no finite
+--- store is not empty, and showing 0 there would read as dry at a glance. A
+--- source that cannot be read says so rather than being guessed at, because a
+--- fabricated zero is the one answer a farmer would act on wrongly.
+local function _waterHours(src)
+    if src == nil then return _T("ft_water_na", "Not available") end
+    if src.unlimited == true then return _T("ft_water_unlimited", "Unlimited") end
+    local cap = tonumber(src.capacity)
+    local rem = tonumber(src.waterRemaining)
+    if cap == nil or rem == nil then return _T("ft_water_na", "Not available") end
+    if src.hasWater == false then return _T("ft_water_dry", "Dry") end
+    return string.format(_T("ft_water_hours", "%.1f / %.1f h"), rem, cap)
+end
+
+--- Stop reason in words, never colour alone. nil means say nothing at all.
+local function _stopWords(reason)
+    if reason == "dry_source" then return _T("ft_water_stop_dry", "Dry source") end
+    if reason == "no_source" then return _T("ft_water_stop_nosource", "No source") end
+    return nil
+end
+
+--- What wakes this pivot next, in the farmer's words. Returns nil when the
+--- snapshot says NONE, so nothing is drawn rather than a made-up promise.
+local function _nextWakeText(sys)
+    local kind = sys.nextWakeKind
+    if kind == nil or kind == "NONE" then return nil end
+    local when = _mins(sys.nextWakeGameMinutes)
+    if kind == "DRY_RESET" then
+        if when then
+            return string.format(_T("ft_rainKey_dryResetIn", "dry reset in %s"), when)
+        end
+        return _T("ft_rainKey_dryResetPending", "dry reset once the rain stops")
+    elseif kind == "NEXT_SCHEDULE_EVALUATION" then
+        if when then
+            return string.format(_T("ft_rainKey_nextCheckIn", "next schedule check %s"), when)
+        end
+        return _T("ft_rainKey_nextCheck", "eligible at the next schedule check")
+    elseif kind == "PLAYER_ACTION" then
+        return _T("ft_rainKey_playerAction", "needs you: check water source")
+    end
+    return nil
+end
+
 local function _soilSystem()
     local mgr = g_currentMission and g_currentMission.soilFertilityManager
     return mgr and mgr.soilSystem or nil
@@ -299,6 +396,76 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
     -- OPERATIONS
     ------------------------------------------------------------------
     if mode == "operations" then
+        -- [BUILD 19:44] HOURS OF WATER.
+        --
+        -- Probe first: an older Crop Stress has no getIrrigationWaterSources, and
+        -- the honest answer there is to omit the whole area rather than draw an
+        -- empty frame that implies the farm has no water. The rain-key list below
+        -- is unaffected either way.
+        local stopById = {}
+        local scsHasWater = scs ~= nil and type(scs.getIrrigationWaterSources) == "function"
+        if scsHasWater then
+            local farmId = nil
+            if self.system ~= nil and self.system.data ~= nil
+               and type(self.system.data.getPlayerFarmId) == "function" then
+                farmId = self.system.data:getPlayerFarmId()
+            end
+
+            if farmId ~= nil and farmId > 0 then
+                -- Stop reasons come from the farmId shape of getIrrigationSystems,
+                -- which is a DIFFERENT table from the no-arg one used for rain-key
+                -- chrome above: it drops the rain-key fields. It is read here only
+                -- for stopReason and merged onto the no-arg rows by system id, so
+                -- the two shapes can never be confused for one another.
+                -- BUILD 22:59: _pcall hands back the payload as its FIRST value (nil on
+                -- failure), the same single-value shape the SYSTEMS read above uses.
+                -- Unpacking it as (ok, payload) put the table in ok and nil in payload,
+                -- so this merge and the WATER SOURCES block below never ran.
+                local farmRows = _pcall(function() return scs:getIrrigationSystems(farmId) end)
+                if type(farmRows) == "table" then
+                    for _, r in ipairs(farmRows) do
+                        local id = r.systemId or r.id
+                        if id ~= nil and r.stopReason ~= nil then stopById[id] = r.stopReason end
+                    end
+                end
+
+                local sources = _pcall(function() return scs:getIrrigationWaterSources(farmId) end)
+                if type(sources) == "table" then
+                    self.r:appText(x, y - FT.py(2), FT.FONT.SMALL,
+                        _T("ft_water_header", "WATER SOURCES"),
+                        RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
+                    y = y - FT.py(16)
+
+                    if #sources == 0 then
+                        self.r:appText(x, y - FT.py(2), FT.FONT.BODY,
+                            _T("ft_water_none", "No water sources on this farm."),
+                            RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                        y = y - FT.py(20)
+                    else
+                        for _, src in ipairs(sources) do
+                            local hours = _waterHours(src)
+                            local dry = (src.unlimited ~= true) and (src.hasWater == false)
+                            local col = dry and FT.C.TEXT_ACCENT or FT.C.TEXT
+                            local label = tostring(src.label or _T("ft_water_source", "Water source"))
+                            self.r:appText(x, y - FT.py(2), FT.FONT.BODY,
+                                FT_Renderer.truncate(string.format("%s #%s",
+                                    label, tostring(src.id or "?")), 22),
+                                RenderText.ALIGN_LEFT, FT.C.TEXT)
+                            self.r:appText(x + cw, y - FT.py(2), FT.FONT.SMALL, hours,
+                                RenderText.ALIGN_RIGHT, col)
+                            y = y - FT.py(14)
+                            local n = #(src.connectedSystems or {})
+                            self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                                string.format(_T("ft_water_connected", "%d connected"), n),
+                                RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                            y = y - FT.py(16)
+                        end
+                    end
+                    y = self:drawRule(y, 0.3)
+                end
+            end
+        end
+
         self.r:appText(x, y - FT.py(2), FT.FONT.SMALL, "SYSTEMS",
             RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
         y = y - FT.py(16)
@@ -308,9 +475,41 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                 "No irrigation systems registered.", RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
             y = y - FT.py(28)
         else
+            -- [SCS-046] Detailed rows are limited to the player's authorized
+            -- farm. Another farm's pivot may still animate in the world from
+            -- public activity, but its private configuration is not exposed
+            -- here. A snapshot with no ownerFarmId (single player, or an older
+            -- SCS that predates the field) is shown, because hiding everything
+            -- on absence would be a worse lie than showing what we have.
+            local viewerFarmId = nil
+            if self.system ~= nil and self.system.data ~= nil
+               and type(self.system.data.getPlayerFarmId) == "function" then
+                viewerFarmId = self.system.data:getPlayerFarmId()
+            end
+
             for _, sys in ipairs(systems) do
-                local state = (sys.isActive and "RUNNING") or "idle"
-                local scol = sys.isActive and FT.C.POSITIVE or FT.C.MUTED
+                local ownerFarmId = sys.ownerFarmId
+                local mayShowDetail = (ownerFarmId == nil) or (viewerFarmId == nil)
+                                      or (ownerFarmId == viewerFarmId)
+
+                -- Activity comes from the snapshot when SCS supplies it. A row
+                -- that says RAIN_PAUSED must never be drawn as RUNNING off
+                -- isActive alone, which is exactly the disagreement the pair
+                -- exists to remove.
+                local activity = sys.activityState
+                local state, scol
+                if activity == "RUNNING" then
+                    state, scol = _lookup(ACTIVITY_TEXT, "RUNNING", "ft_rainKey_running", "RUNNING"), FT.C.POSITIVE
+                elseif activity == "RAIN_PAUSED" then
+                    state, scol = _lookup(ACTIVITY_TEXT, "RAIN_PAUSED", "ft_rainKey_rainPaused", "RAIN PAUSED"), FT.C.TEXT_ACCENT
+                elseif activity == "OFF" then
+                    state, scol = _lookup(ACTIVITY_TEXT, "OFF", "ft_rainKey_off", "off"), FT.C.MUTED
+                else
+                    -- No activityState in this snapshot: fall back to the
+                    -- incumbent reading rather than inventing one.
+                    state = (sys.isActive and "RUNNING") or "idle"
+                    scol  = sys.isActive and FT.C.POSITIVE or FT.C.MUTED
+                end
                 local coverN = #(sys.coveredFields or {})
                 self.r:appText(x, y - FT.py(2), FT.FONT.BODY,
                     FT_Renderer.truncate(string.format("#%s  %s",
@@ -331,7 +530,66 @@ FarmTabletUI:registerDrawer(FT.APP.IRRIGATION_SUITE, function(self)
                     string.format("%s  ·  %d fields  ·  flow %.2f/h",
                         schedTxt, coverN, tonumber(sys.flowRatePerHour) or 0),
                     RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-                y = y - FT.py(16)
+                y = y - FT.py(14)
+
+                -- [SCS-046] Rain-key line. Answers, in order: is a key fitted,
+                -- what is the sensor doing, how much has collected against this
+                -- machine's trip amount, and what wakes it next.
+                if mayShowDetail and sys.rainKeyState ~= nil then
+                    local keyState = sys.rainKeyState
+                    local keyTxt = _lookup(RAIN_KEY_STATE_TEXT, keyState,
+                                           "ft_rainKey_unknownState", "rain key state unknown")
+                    local keyCol = FT.C.TEXT_DIM
+                    if keyState == "TRIPPED" then
+                        keyCol = FT.C.TEXT_ACCENT
+                    elseif keyState == "INPUT_UNAVAILABLE" then
+                        keyCol = FT.C.MUTED
+                    end
+
+                    if sys.rainKeyFitted == true then
+                        -- Collected against trip, both in modelled mm and both
+                        -- honest about absence.
+                        local collected = _mm(sys.rainKeyAccumulatedMm)
+                        local trip      = _mm(sys.rainKeyTripMm)
+                        if sys.weatherReadable == false then
+                            collected = _T("ft_rainKey_unknown", "unknown")
+                        end
+                        self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                            FT_Renderer.truncate(string.format("%s  ·  %s %s / %s %s",
+                                keyTxt,
+                                _T("ft_rainKey_collected", "collected"), collected,
+                                _T("ft_rainKey_trip", "trip"), trip), 46),
+                            RenderText.ALIGN_LEFT, keyCol)
+                        y = y - FT.py(13)
+
+                        -- Why it is not running, then what happens next. Only
+                        -- printed when the snapshot actually says something.
+                        local bits = {}
+                        local reason = sys.pauseReason
+                        if reason ~= nil and reason ~= "NONE" and activity ~= "RUNNING" then
+                            bits[#bits + 1] = _lookup(PAUSE_REASON_TEXT, reason,
+                                                      "ft_rainKey_whyUnknown", "reason unavailable")
+                        end
+                        local nextTxt = _nextWakeText(sys)
+                        if nextTxt ~= nil then bits[#bits + 1] = nextTxt end
+                        -- [BUILD 19:44] Why a stopped system is stopped, in words
+                        -- rather than colour alone. Merged by system id from the
+                        -- farmId shape; nil simply says nothing.
+                        local stopTxt = _stopWords(stopById[sys.systemId or sys.id])
+                        if stopTxt ~= nil then bits[#bits + 1] = stopTxt end
+                        if #bits > 0 then
+                            self.r:appText(x, y - FT.py(1), FT.FONT.SMALL,
+                                FT_Renderer.truncate(table.concat(bits, "  ·  "), 46),
+                                RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
+                            y = y - FT.py(13)
+                        end
+                    else
+                        self.r:appText(x, y - FT.py(1), FT.FONT.SMALL, keyTxt,
+                            RenderText.ALIGN_LEFT, FT.C.MUTED)
+                        y = y - FT.py(13)
+                    end
+                end
+                y = y - FT.py(3)
             end
         end
 

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="pode aguardar" />
         <text name="ft_irr_advisory_schedule_covers" text="programa cobre" />
         <text name="ft_irr_advisory_schedule_gap" text="falha no programa" />
+        <text name="ft_rainKey_unknown" text="desconhecido" />
+        <text name="ft_rainKey_mm" text="mm modelados" />
+        <text name="ft_rainKey_unfitted" text="sem sensor de chuva" />
+        <text name="ft_rainKey_armed" text="sensor armado" />
+        <text name="ft_rainKey_collecting" text="coletando chuva" />
+        <text name="ft_rainKey_tripped" text="sensor disparado" />
+        <text name="ft_rainKey_inputUnavail" text="entrada do sensor indisponivel" />
+        <text name="ft_rainKey_whyTripped" text="parado porque o sensor de chuva disparou" />
+        <text name="ft_rainKey_whyNoInput" text="nao e possivel ler o clima" />
+        <text name="ft_rainKey_whyNoSource" text="sem fonte de agua" />
+        <text name="ft_rainKey_whyNoPress" text="sem pressao" />
+        <text name="ft_rainKey_whySchedule" text="fora do horario" />
+        <text name="ft_rainKey_whyMaster" text="chave geral de irrigacao desligada" />
+        <text name="ft_rainKey_whyUnknown" text="motivo indisponivel" />
+        <text name="ft_rainKey_running" text="EM OPERACAO" />
+        <text name="ft_rainKey_rainPaused" text="PAUSA POR CHUVA" />
+        <text name="ft_rainKey_off" text="desligado" />
+        <text name="ft_rainKey_unknownState" text="estado do sensor desconhecido" />
+        <text name="ft_rainKey_dryResetIn" text="reinicio seco em %s" />
+        <text name="ft_rainKey_dryResetPending" text="reinicio quando a chuva parar" />
+        <text name="ft_rainKey_nextCheckIn" text="proxima verificacao %s" />
+        <text name="ft_rainKey_nextCheck" text="elegivel na proxima verificacao do horario" />
+        <text name="ft_rainKey_playerAction" text="requer acao: verifique a fonte de agua" />
+        <text name="ft_rainKey_collected" text="coletado" />
+        <text name="ft_rainKey_trip" text="limite" />
+        <text name="ft_rainKey_notifyTitle" text="Irrigacao" />
+        <text name="ft_rainKey_notifyPaused" text="O pivo #%s parou porque o sensor de chuva disparou" />
+        <text name="ft_rainKey_notifyResumed" text="O pivo #%s fica elegivel novamente na proxima verificacao" />
+        <text name="ft_water_header" text="FONTES DE AGUA" />
+        <text name="ft_water_unlimited" text="Ilimitado" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Seca" />
+        <text name="ft_water_na" text="Indisponivel" />
+        <text name="ft_water_none" text="Sem fontes de agua nesta fazenda." />
+        <text name="ft_water_source" text="Fonte de agua" />
+        <text name="ft_water_connected" text="%d conectados" />
+        <text name="ft_water_stop_dry" text="Fonte seca" />
+        <text name="ft_water_stop_nosource" text="Sem fonte" />
     </texts>
 
 

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="可等待" />
         <text name="ft_irr_advisory_schedule_covers" text="計畫涵蓋" />
         <text name="ft_irr_advisory_schedule_gap" text="計畫缺口" />
+        <text name="ft_rainKey_unknown" text="未知" />
+        <text name="ft_rainKey_mm" text="模擬毫米" />
+        <text name="ft_rainKey_unfitted" text="未安裝雨量感測器" />
+        <text name="ft_rainKey_armed" text="感測器待命" />
+        <text name="ft_rainKey_collecting" text="正在收集雨量" />
+        <text name="ft_rainKey_tripped" text="感測器已觸發" />
+        <text name="ft_rainKey_inputUnavail" text="感測器資料無法讀取" />
+        <text name="ft_rainKey_whyTripped" text="因雨量感測器觸發而停止" />
+        <text name="ft_rainKey_whyNoInput" text="無法讀取天氣" />
+        <text name="ft_rainKey_whyNoSource" text="沒有水源" />
+        <text name="ft_rainKey_whyNoPress" text="沒有壓力" />
+        <text name="ft_rainKey_whySchedule" text="不在排程時段" />
+        <text name="ft_rainKey_whyMaster" text="灌溉總開關已關閉" />
+        <text name="ft_rainKey_whyUnknown" text="原因不明" />
+        <text name="ft_rainKey_running" text="運轉中" />
+        <text name="ft_rainKey_rainPaused" text="因雨暫停" />
+        <text name="ft_rainKey_off" text="關閉" />
+        <text name="ft_rainKey_unknownState" text="感測器狀態不明" />
+        <text name="ft_rainKey_dryResetIn" text="%s 後乾燥重設" />
+        <text name="ft_rainKey_dryResetPending" text="雨停後重設" />
+        <text name="ft_rainKey_nextCheckIn" text="下次排程檢查 %s" />
+        <text name="ft_rainKey_nextCheck" text="下次排程檢查時可運轉" />
+        <text name="ft_rainKey_playerAction" text="需要處理: 請檢查水源" />
+        <text name="ft_rainKey_collected" text="已收集" />
+        <text name="ft_rainKey_trip" text="門檻" />
+        <text name="ft_rainKey_notifyTitle" text="灌溉" />
+        <text name="ft_rainKey_notifyPaused" text="樞軸 #%s 因雨量感測器而停止" />
+        <text name="ft_rainKey_notifyResumed" text="樞軸 #%s 將於下次排程檢查時恢復" />
+        <text name="ft_water_header" text="水源" />
+        <text name="ft_water_unlimited" text="無限" />
+        <text name="ft_water_hours" text="%.1f / %.1f 小時" />
+        <text name="ft_water_dry" text="乾涸" />
+        <text name="ft_water_na" text="無法取得" />
+        <text name="ft_water_none" text="這座農場沒有水源。" />
+        <text name="ft_water_source" text="水源" />
+        <text name="ft_water_connected" text="已連接 %d" />
+        <text name="ft_water_stop_dry" text="水源乾涸" />
+        <text name="ft_water_stop_nosource" text="沒有水源" />
     </texts>
 
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="může počkat" />
         <text name="ft_irr_advisory_schedule_covers" text="plán pokrývá" />
         <text name="ft_irr_advisory_schedule_gap" text="mezera v plánu" />
+        <text name="ft_rainKey_unknown" text="neznamo" />
+        <text name="ft_rainKey_mm" text="mm modelovanych" />
+        <text name="ft_rainKey_unfitted" text="bez cidla deste" />
+        <text name="ft_rainKey_armed" text="cidlo aktivni" />
+        <text name="ft_rainKey_collecting" text="sbira dest" />
+        <text name="ft_rainKey_tripped" text="cidlo sepnulo" />
+        <text name="ft_rainKey_inputUnavail" text="vstup cidla nedostupny" />
+        <text name="ft_rainKey_whyTripped" text="zastaveno, protoze sepnulo cidlo deste" />
+        <text name="ft_rainKey_whyNoInput" text="pocasi nelze precist" />
+        <text name="ft_rainKey_whyNoSource" text="zadny zdroj vody" />
+        <text name="ft_rainKey_whyNoPress" text="zadny tlak" />
+        <text name="ft_rainKey_whySchedule" text="mimo harmonogram" />
+        <text name="ft_rainKey_whyMaster" text="hlavni vypinac zavlahy vypnuty" />
+        <text name="ft_rainKey_whyUnknown" text="duvod nedostupny" />
+        <text name="ft_rainKey_running" text="BEZI" />
+        <text name="ft_rainKey_rainPaused" text="PAUZA KVULI DESTI" />
+        <text name="ft_rainKey_off" text="vypnuto" />
+        <text name="ft_rainKey_unknownState" text="stav cidla neznamy" />
+        <text name="ft_rainKey_dryResetIn" text="suchy reset za %s" />
+        <text name="ft_rainKey_dryResetPending" text="reset, az dest ustane" />
+        <text name="ft_rainKey_nextCheckIn" text="dalsi kontrola %s" />
+        <text name="ft_rainKey_nextCheck" text="pripraveno pri dalsi kontrole harmonogramu" />
+        <text name="ft_rainKey_playerAction" text="vyzaduje zasah: zkontrolujte zdroj vody" />
+        <text name="ft_rainKey_collected" text="nasbirano" />
+        <text name="ft_rainKey_trip" text="prah" />
+        <text name="ft_rainKey_notifyTitle" text="Zavlaha" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s zastaven cidlem deste" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s bude znovu pripraven pri dalsi kontrole" />
+        <text name="ft_water_header" text="ZDROJE VODY" />
+        <text name="ft_water_unlimited" text="Neomezene" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Sucho" />
+        <text name="ft_water_na" text="Nedostupne" />
+        <text name="ft_water_none" text="Na teto farme nejsou zdroje vody." />
+        <text name="ft_water_source" text="Zdroj vody" />
+        <text name="ft_water_connected" text="%d pripojeno" />
+        <text name="ft_water_stop_dry" text="Zdroj vyschl" />
+        <text name="ft_water_stop_nosource" text="Zadny zdroj" />
     </texts>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="kan vente" />
         <text name="ft_irr_advisory_schedule_covers" text="plan dækker" />
         <text name="ft_irr_advisory_schedule_gap" text="planhul" />
+        <text name="ft_rainKey_unknown" text="ukendt" />
+        <text name="ft_rainKey_mm" text="modellerede mm" />
+        <text name="ft_rainKey_unfitted" text="ingen regnsensor monteret" />
+        <text name="ft_rainKey_armed" text="sensor aktiveret" />
+        <text name="ft_rainKey_collecting" text="opsamler regn" />
+        <text name="ft_rainKey_tripped" text="sensor udlost" />
+        <text name="ft_rainKey_inputUnavail" text="sensordata utilgaengelige" />
+        <text name="ft_rainKey_whyTripped" text="stoppet fordi regnsensoren blev udlost" />
+        <text name="ft_rainKey_whyNoInput" text="kan ikke laese vejret" />
+        <text name="ft_rainKey_whyNoSource" text="ingen vandkilde" />
+        <text name="ft_rainKey_whyNoPress" text="intet tryk" />
+        <text name="ft_rainKey_whySchedule" text="uden for planen" />
+        <text name="ft_rainKey_whyMaster" text="hovedafbryder for vanding slukket" />
+        <text name="ft_rainKey_whyUnknown" text="arsag utilgaengelig" />
+        <text name="ft_rainKey_running" text="I DRIFT" />
+        <text name="ft_rainKey_rainPaused" text="REGNPAUSE" />
+        <text name="ft_rainKey_off" text="fra" />
+        <text name="ft_rainKey_unknownState" text="sensorstatus ukendt" />
+        <text name="ft_rainKey_dryResetIn" text="tor nulstilling om %s" />
+        <text name="ft_rainKey_dryResetPending" text="nulstilling nar regnen stopper" />
+        <text name="ft_rainKey_nextCheckIn" text="naeste plankontrol %s" />
+        <text name="ft_rainKey_nextCheck" text="klar ved naeste plankontrol" />
+        <text name="ft_rainKey_playerAction" text="kraever handling: kontroller vandkilden" />
+        <text name="ft_rainKey_collected" text="opsamlet" />
+        <text name="ft_rainKey_trip" text="graense" />
+        <text name="ft_rainKey_notifyTitle" text="Vanding" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s stoppede pa grund af regnsensoren" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s er klar igen ved naeste plankontrol" />
+        <text name="ft_water_header" text="VANDKILDER" />
+        <text name="ft_water_unlimited" text="Ubegraenset" />
+        <text name="ft_water_hours" text="%.1f / %.1f t" />
+        <text name="ft_water_dry" text="Tor" />
+        <text name="ft_water_na" text="Utilgaengelig" />
+        <text name="ft_water_none" text="Ingen vandkilder pa denne gard." />
+        <text name="ft_water_source" text="Vandkilde" />
+        <text name="ft_water_connected" text="%d tilsluttet" />
+        <text name="ft_water_stop_dry" text="Kilden er tor" />
+        <text name="ft_water_stop_nosource" text="Ingen kilde" />
     </texts>
 
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="kann halten" />
         <text name="ft_irr_advisory_schedule_covers" text="Plan abgedeckt" />
         <text name="ft_irr_advisory_schedule_gap" text="Planlücke" />
+        <text name="ft_rainKey_unknown" text="unbekannt" />
+        <text name="ft_rainKey_mm" text="mm modelliert" />
+        <text name="ft_rainKey_unfitted" text="kein Regensensor verbaut" />
+        <text name="ft_rainKey_armed" text="Regensensor scharf" />
+        <text name="ft_rainKey_collecting" text="sammelt Regen" />
+        <text name="ft_rainKey_tripped" text="Regensensor ausgeloest" />
+        <text name="ft_rainKey_inputUnavail" text="Sensordaten nicht verfuegbar" />
+        <text name="ft_rainKey_whyTripped" text="gestoppt, weil der Regensensor ausgeloest hat" />
+        <text name="ft_rainKey_whyNoInput" text="Wetter nicht lesbar" />
+        <text name="ft_rainKey_whyNoSource" text="keine Wasserquelle" />
+        <text name="ft_rainKey_whyNoPress" text="kein Druck" />
+        <text name="ft_rainKey_whySchedule" text="ausserhalb des Zeitplans" />
+        <text name="ft_rainKey_whyMaster" text="Bewaesserung-Hauptschalter aus" />
+        <text name="ft_rainKey_whyUnknown" text="Grund nicht verfuegbar" />
+        <text name="ft_rainKey_running" text="LAEUFT" />
+        <text name="ft_rainKey_rainPaused" text="REGENPAUSE" />
+        <text name="ft_rainKey_off" text="aus" />
+        <text name="ft_rainKey_unknownState" text="Sensorstatus unbekannt" />
+        <text name="ft_rainKey_dryResetIn" text="Trockenreset in %s" />
+        <text name="ft_rainKey_dryResetPending" text="Trockenreset, sobald der Regen aufhoert" />
+        <text name="ft_rainKey_nextCheckIn" text="naechste Zeitplanpruefung %s" />
+        <text name="ft_rainKey_nextCheck" text="beim naechsten Zeitplan wieder bereit" />
+        <text name="ft_rainKey_playerAction" text="Aktion noetig: Wasserquelle pruefen" />
+        <text name="ft_rainKey_collected" text="gesammelt" />
+        <text name="ft_rainKey_trip" text="Schwelle" />
+        <text name="ft_rainKey_notifyTitle" text="Bewaesserung" />
+        <text name="ft_rainKey_notifyPaused" text="Kreisberegner #%s wurde vom Regensensor gestoppt" />
+        <text name="ft_rainKey_notifyResumed" text="Kreisberegner #%s ist bei der naechsten Zeitplanpruefung wieder bereit" />
+        <text name="ft_water_header" text="WASSERQUELLEN" />
+        <text name="ft_water_unlimited" text="Unbegrenzt" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Trocken" />
+        <text name="ft_water_na" text="Nicht verfuegbar" />
+        <text name="ft_water_none" text="Keine Wasserquellen auf diesem Hof." />
+        <text name="ft_water_source" text="Wasserquelle" />
+        <text name="ft_water_connected" text="%d verbunden" />
+        <text name="ft_water_stop_dry" text="Quelle trocken" />
+        <text name="ft_water_stop_nosource" text="Keine Quelle" />
     </texts>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="puede esperar" />
         <text name="ft_irr_advisory_schedule_covers" text="el plan cubre" />
         <text name="ft_irr_advisory_schedule_gap" text="hueco de plan" />
+        <text name="ft_rainKey_unknown" text="desconocido" />
+        <text name="ft_rainKey_mm" text="mm modelados" />
+        <text name="ft_rainKey_unfitted" text="sin sensor de lluvia" />
+        <text name="ft_rainKey_armed" text="sensor armado" />
+        <text name="ft_rainKey_collecting" text="recogiendo lluvia" />
+        <text name="ft_rainKey_tripped" text="sensor activado" />
+        <text name="ft_rainKey_inputUnavail" text="entrada del sensor no disponible" />
+        <text name="ft_rainKey_whyTripped" text="detenido porque el sensor de lluvia se activo" />
+        <text name="ft_rainKey_whyNoInput" text="no se puede leer el clima" />
+        <text name="ft_rainKey_whyNoSource" text="sin fuente de agua" />
+        <text name="ft_rainKey_whyNoPress" text="sin presion" />
+        <text name="ft_rainKey_whySchedule" text="fuera del horario" />
+        <text name="ft_rainKey_whyMaster" text="interruptor general de riego apagado" />
+        <text name="ft_rainKey_whyUnknown" text="motivo no disponible" />
+        <text name="ft_rainKey_running" text="EN MARCHA" />
+        <text name="ft_rainKey_rainPaused" text="PAUSA POR LLUVIA" />
+        <text name="ft_rainKey_off" text="apagado" />
+        <text name="ft_rainKey_unknownState" text="estado del sensor desconocido" />
+        <text name="ft_rainKey_dryResetIn" text="reinicio seco en %s" />
+        <text name="ft_rainKey_dryResetPending" text="reinicio cuando pare la lluvia" />
+        <text name="ft_rainKey_nextCheckIn" text="proxima revision %s" />
+        <text name="ft_rainKey_nextCheck" text="disponible en la proxima revision del horario" />
+        <text name="ft_rainKey_playerAction" text="requiere accion: revisar la fuente de agua" />
+        <text name="ft_rainKey_collected" text="recogido" />
+        <text name="ft_rainKey_trip" text="umbral" />
+        <text name="ft_rainKey_notifyTitle" text="Riego" />
+        <text name="ft_rainKey_notifyPaused" text="El pivote #%s se detuvo porque el sensor de lluvia se activo" />
+        <text name="ft_rainKey_notifyResumed" text="El pivote #%s vuelve a estar disponible en la proxima revision" />
+        <text name="ft_water_header" text="FUENTES DE AGUA" />
+        <text name="ft_water_unlimited" text="Ilimitado" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Seca" />
+        <text name="ft_water_na" text="No disponible" />
+        <text name="ft_water_none" text="Sin fuentes de agua en esta granja." />
+        <text name="ft_water_source" text="Fuente de agua" />
+        <text name="ft_water_connected" text="%d conectados" />
+        <text name="ft_water_stop_dry" text="Fuente seca" />
+        <text name="ft_water_stop_nosource" text="Sin fuente" />
     </texts>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -2549,6 +2549,44 @@
         <text name="ft_irr_call_can_hold" text="can hold" />
         <text name="ft_irr_advisory_schedule_covers" text="schedule covers" />
         <text name="ft_irr_advisory_schedule_gap" text="schedule gap" />
+        <text name="ft_rainKey_unknown" text="unknown" />
+        <text name="ft_rainKey_mm" text="mm modelled" />
+        <text name="ft_rainKey_unfitted" text="no rain key fitted" />
+        <text name="ft_rainKey_armed" text="rain key armed" />
+        <text name="ft_rainKey_collecting" text="collecting rain" />
+        <text name="ft_rainKey_tripped" text="rain key tripped" />
+        <text name="ft_rainKey_inputUnavail" text="sensor input unavailable" />
+        <text name="ft_rainKey_whyTripped" text="stopped because the rain key tripped" />
+        <text name="ft_rainKey_whyNoInput" text="cannot read weather" />
+        <text name="ft_rainKey_whyNoSource" text="no water source" />
+        <text name="ft_rainKey_whyNoPress" text="no pressure" />
+        <text name="ft_rainKey_whySchedule" text="outside the schedule" />
+        <text name="ft_rainKey_whyMaster" text="irrigation master switch off" />
+        <text name="ft_rainKey_whyUnknown" text="reason unavailable" />
+        <text name="ft_rainKey_running" text="RUNNING" />
+        <text name="ft_rainKey_rainPaused" text="RAIN PAUSED" />
+        <text name="ft_rainKey_off" text="off" />
+        <text name="ft_rainKey_unknownState" text="rain key state unknown" />
+        <text name="ft_rainKey_dryResetIn" text="dry reset in %s" />
+        <text name="ft_rainKey_dryResetPending" text="dry reset once the rain stops" />
+        <text name="ft_rainKey_nextCheckIn" text="next schedule check %s" />
+        <text name="ft_rainKey_nextCheck" text="eligible at the next schedule check" />
+        <text name="ft_rainKey_playerAction" text="needs you: check water source" />
+        <text name="ft_rainKey_collected" text="collected" />
+        <text name="ft_rainKey_trip" text="trip" />
+        <text name="ft_rainKey_notifyTitle" text="Irrigation" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s stopped because the rain key tripped" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s is eligible again at the next schedule check" />
+        <text name="ft_water_header" text="WATER SOURCES" />
+        <text name="ft_water_unlimited" text="Unlimited" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Dry" />
+        <text name="ft_water_na" text="Not available" />
+        <text name="ft_water_none" text="No water sources on this farm." />
+        <text name="ft_water_source" text="Water source" />
+        <text name="ft_water_connected" text="%d connected" />
+        <text name="ft_water_stop_dry" text="Dry source" />
+        <text name="ft_water_stop_nosource" text="No source" />
     </texts>
 
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="puede esperar" />
         <text name="ft_irr_advisory_schedule_covers" text="el plan cubre" />
         <text name="ft_irr_advisory_schedule_gap" text="hueco de plan" />
+        <text name="ft_rainKey_unknown" text="desconocido" />
+        <text name="ft_rainKey_mm" text="mm modelados" />
+        <text name="ft_rainKey_unfitted" text="sin sensor de lluvia" />
+        <text name="ft_rainKey_armed" text="sensor armado" />
+        <text name="ft_rainKey_collecting" text="recogiendo lluvia" />
+        <text name="ft_rainKey_tripped" text="sensor activado" />
+        <text name="ft_rainKey_inputUnavail" text="entrada del sensor no disponible" />
+        <text name="ft_rainKey_whyTripped" text="detenido porque el sensor de lluvia se activo" />
+        <text name="ft_rainKey_whyNoInput" text="no se puede leer el clima" />
+        <text name="ft_rainKey_whyNoSource" text="sin fuente de agua" />
+        <text name="ft_rainKey_whyNoPress" text="sin presion" />
+        <text name="ft_rainKey_whySchedule" text="fuera del horario" />
+        <text name="ft_rainKey_whyMaster" text="interruptor general de riego apagado" />
+        <text name="ft_rainKey_whyUnknown" text="motivo no disponible" />
+        <text name="ft_rainKey_running" text="EN MARCHA" />
+        <text name="ft_rainKey_rainPaused" text="PAUSA POR LLUVIA" />
+        <text name="ft_rainKey_off" text="apagado" />
+        <text name="ft_rainKey_unknownState" text="estado del sensor desconocido" />
+        <text name="ft_rainKey_dryResetIn" text="reinicio seco en %s" />
+        <text name="ft_rainKey_dryResetPending" text="reinicio cuando pare la lluvia" />
+        <text name="ft_rainKey_nextCheckIn" text="proxima revision %s" />
+        <text name="ft_rainKey_nextCheck" text="disponible en la proxima revision del horario" />
+        <text name="ft_rainKey_playerAction" text="requiere accion: revisar la fuente de agua" />
+        <text name="ft_rainKey_collected" text="recogido" />
+        <text name="ft_rainKey_trip" text="umbral" />
+        <text name="ft_rainKey_notifyTitle" text="Riego" />
+        <text name="ft_rainKey_notifyPaused" text="El pivote #%s se detuvo porque el sensor de lluvia se activo" />
+        <text name="ft_rainKey_notifyResumed" text="El pivote #%s vuelve a estar disponible en la proxima revision" />
+        <text name="ft_water_header" text="FUENTES DE AGUA" />
+        <text name="ft_water_unlimited" text="Ilimitado" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Seca" />
+        <text name="ft_water_na" text="No disponible" />
+        <text name="ft_water_none" text="Sin fuentes de agua en esta granja." />
+        <text name="ft_water_source" text="Fuente de agua" />
+        <text name="ft_water_connected" text="%d conectados" />
+        <text name="ft_water_stop_dry" text="Fuente seca" />
+        <text name="ft_water_stop_nosource" text="Sin fuente" />
     </texts>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="可等待" />
         <text name="ft_irr_advisory_schedule_covers" text="计划涵盖" />
         <text name="ft_irr_advisory_schedule_gap" text="计划缺口" />
+        <text name="ft_rainKey_unknown" text="未知" />
+        <text name="ft_rainKey_mm" text="模拟毫米" />
+        <text name="ft_rainKey_unfitted" text="未安装雨量传感器" />
+        <text name="ft_rainKey_armed" text="传感器待命" />
+        <text name="ft_rainKey_collecting" text="正在收集雨量" />
+        <text name="ft_rainKey_tripped" text="传感器已触发" />
+        <text name="ft_rainKey_inputUnavail" text="传感器数据不可用" />
+        <text name="ft_rainKey_whyTripped" text="因雨量传感器触发而停止" />
+        <text name="ft_rainKey_whyNoInput" text="无法读取天气" />
+        <text name="ft_rainKey_whyNoSource" text="没有水源" />
+        <text name="ft_rainKey_whyNoPress" text="没有压力" />
+        <text name="ft_rainKey_whySchedule" text="不在计划时段" />
+        <text name="ft_rainKey_whyMaster" text="灌溉总开关已关闭" />
+        <text name="ft_rainKey_whyUnknown" text="原因不明" />
+        <text name="ft_rainKey_running" text="运行中" />
+        <text name="ft_rainKey_rainPaused" text="因雨暂停" />
+        <text name="ft_rainKey_off" text="关闭" />
+        <text name="ft_rainKey_unknownState" text="传感器状态不明" />
+        <text name="ft_rainKey_dryResetIn" text="%s 后干燥重置" />
+        <text name="ft_rainKey_dryResetPending" text="雨停后重置" />
+        <text name="ft_rainKey_nextCheckIn" text="下次计划检查 %s" />
+        <text name="ft_rainKey_nextCheck" text="下次计划检查时可运行" />
+        <text name="ft_rainKey_playerAction" text="需要处理: 请检查水源" />
+        <text name="ft_rainKey_collected" text="已收集" />
+        <text name="ft_rainKey_trip" text="阈值" />
+        <text name="ft_rainKey_notifyTitle" text="灌溉" />
+        <text name="ft_rainKey_notifyPaused" text="中心支轴 #%s 因雨量传感器而停止" />
+        <text name="ft_rainKey_notifyResumed" text="中心支轴 #%s 将在下次计划检查时恢复" />
+        <text name="ft_water_header" text="水源" />
+        <text name="ft_water_unlimited" text="无限" />
+        <text name="ft_water_hours" text="%.1f / %.1f 小时" />
+        <text name="ft_water_dry" text="干涸" />
+        <text name="ft_water_na" text="无法获取" />
+        <text name="ft_water_none" text="这个农场没有水源。" />
+        <text name="ft_water_source" text="水源" />
+        <text name="ft_water_connected" text="已连接 %d" />
+        <text name="ft_water_stop_dry" text="水源干涸" />
+        <text name="ft_water_stop_nosource" text="没有水源" />
     </texts>
 
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="voi odottaa" />
         <text name="ft_irr_advisory_schedule_covers" text="aikataulu kattaa" />
         <text name="ft_irr_advisory_schedule_gap" text="aikataulun aukko" />
+        <text name="ft_rainKey_unknown" text="tuntematon" />
+        <text name="ft_rainKey_mm" text="mallinnettua mm" />
+        <text name="ft_rainKey_unfitted" text="ei sadeanturia" />
+        <text name="ft_rainKey_armed" text="anturi valmiina" />
+        <text name="ft_rainKey_collecting" text="kerää sadetta" />
+        <text name="ft_rainKey_tripped" text="anturi lauennut" />
+        <text name="ft_rainKey_inputUnavail" text="anturitieto ei saatavilla" />
+        <text name="ft_rainKey_whyTripped" text="pysaytetty, koska sadeanturi laukesi" />
+        <text name="ft_rainKey_whyNoInput" text="saatietoa ei voi lukea" />
+        <text name="ft_rainKey_whyNoSource" text="ei vesilahdetta" />
+        <text name="ft_rainKey_whyNoPress" text="ei painetta" />
+        <text name="ft_rainKey_whySchedule" text="aikataulun ulkopuolella" />
+        <text name="ft_rainKey_whyMaster" text="kastelun paakytkin pois" />
+        <text name="ft_rainKey_whyUnknown" text="syy ei saatavilla" />
+        <text name="ft_rainKey_running" text="KAY" />
+        <text name="ft_rainKey_rainPaused" text="SADETAUKO" />
+        <text name="ft_rainKey_off" text="pois" />
+        <text name="ft_rainKey_unknownState" text="anturin tila tuntematon" />
+        <text name="ft_rainKey_dryResetIn" text="kuiva nollaus %s kuluttua" />
+        <text name="ft_rainKey_dryResetPending" text="nollaus kun sade lakkaa" />
+        <text name="ft_rainKey_nextCheckIn" text="seuraava aikataulutarkistus %s" />
+        <text name="ft_rainKey_nextCheck" text="kelpoinen seuraavassa aikataulutarkistuksessa" />
+        <text name="ft_rainKey_playerAction" text="vaatii toimia: tarkista vesilahde" />
+        <text name="ft_rainKey_collected" text="kerätty" />
+        <text name="ft_rainKey_trip" text="raja" />
+        <text name="ft_rainKey_notifyTitle" text="Kastelu" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s pysahtyi sadeanturin vuoksi" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s on taas kelpoinen seuraavassa tarkistuksessa" />
+        <text name="ft_water_header" text="VESILAHTEET" />
+        <text name="ft_water_unlimited" text="Rajaton" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Kuiva" />
+        <text name="ft_water_na" text="Ei saatavilla" />
+        <text name="ft_water_none" text="Talla tilalla ei ole vesilahteita." />
+        <text name="ft_water_source" text="Vesilahde" />
+        <text name="ft_water_connected" text="%d liitetty" />
+        <text name="ft_water_stop_dry" text="Lahde kuiva" />
+        <text name="ft_water_stop_nosource" text="Ei lahdetta" />
     </texts>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="peut attendre" />
         <text name="ft_irr_advisory_schedule_covers" text="plan couvre" />
         <text name="ft_irr_advisory_schedule_gap" text="trou de plan" />
+        <text name="ft_rainKey_unknown" text="inconnu" />
+        <text name="ft_rainKey_mm" text="mm modelises" />
+        <text name="ft_rainKey_unfitted" text="pas de capteur de pluie" />
+        <text name="ft_rainKey_armed" text="capteur arme" />
+        <text name="ft_rainKey_collecting" text="collecte de pluie" />
+        <text name="ft_rainKey_tripped" text="capteur declenche" />
+        <text name="ft_rainKey_inputUnavail" text="donnees capteur indisponibles" />
+        <text name="ft_rainKey_whyTripped" text="arrete car le capteur de pluie a declenche" />
+        <text name="ft_rainKey_whyNoInput" text="meteo illisible" />
+        <text name="ft_rainKey_whyNoSource" text="pas de source d'eau" />
+        <text name="ft_rainKey_whyNoPress" text="pas de pression" />
+        <text name="ft_rainKey_whySchedule" text="hors du programme" />
+        <text name="ft_rainKey_whyMaster" text="interrupteur general d'irrigation coupe" />
+        <text name="ft_rainKey_whyUnknown" text="raison indisponible" />
+        <text name="ft_rainKey_running" text="EN MARCHE" />
+        <text name="ft_rainKey_rainPaused" text="PAUSE PLUIE" />
+        <text name="ft_rainKey_off" text="arret" />
+        <text name="ft_rainKey_unknownState" text="etat du capteur inconnu" />
+        <text name="ft_rainKey_dryResetIn" text="reinitialisation dans %s" />
+        <text name="ft_rainKey_dryResetPending" text="reinitialisation des l'arret de la pluie" />
+        <text name="ft_rainKey_nextCheckIn" text="prochain controle %s" />
+        <text name="ft_rainKey_nextCheck" text="eligible au prochain controle du programme" />
+        <text name="ft_rainKey_playerAction" text="action requise: verifier la source d'eau" />
+        <text name="ft_rainKey_collected" text="collecte" />
+        <text name="ft_rainKey_trip" text="seuil" />
+        <text name="ft_rainKey_notifyTitle" text="Irrigation" />
+        <text name="ft_rainKey_notifyPaused" text="Le pivot #%s s'est arrete car le capteur de pluie a declenche" />
+        <text name="ft_rainKey_notifyResumed" text="Le pivot #%s sera de nouveau eligible au prochain controle" />
+        <text name="ft_water_header" text="SOURCES D'EAU" />
+        <text name="ft_water_unlimited" text="Illimite" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="A sec" />
+        <text name="ft_water_na" text="Indisponible" />
+        <text name="ft_water_none" text="Aucune source d'eau sur cette ferme." />
+        <text name="ft_water_source" text="Source d'eau" />
+        <text name="ft_water_connected" text="%d connectes" />
+        <text name="ft_water_stop_dry" text="Source a sec" />
+        <text name="ft_water_stop_nosource" text="Aucune source" />
     </texts>
 
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="várhat" />
         <text name="ft_irr_advisory_schedule_covers" text="a terv lefedi" />
         <text name="ft_irr_advisory_schedule_gap" text="tervhézag" />
+        <text name="ft_rainKey_unknown" text="ismeretlen" />
+        <text name="ft_rainKey_mm" text="modellezett mm" />
+        <text name="ft_rainKey_unfitted" text="nincs esoerzekelo" />
+        <text name="ft_rainKey_armed" text="erzekelo elesitve" />
+        <text name="ft_rainKey_collecting" text="esot gyujt" />
+        <text name="ft_rainKey_tripped" text="erzekelo jelzett" />
+        <text name="ft_rainKey_inputUnavail" text="erzekelo adata nem elerheto" />
+        <text name="ft_rainKey_whyTripped" text="leallt, mert az esoerzekelo jelzett" />
+        <text name="ft_rainKey_whyNoInput" text="az idojaras nem olvashato" />
+        <text name="ft_rainKey_whyNoSource" text="nincs vizforras" />
+        <text name="ft_rainKey_whyNoPress" text="nincs nyomas" />
+        <text name="ft_rainKey_whySchedule" text="a menetrenden kivul" />
+        <text name="ft_rainKey_whyMaster" text="az ontozes fokapcsoloja ki van kapcsolva" />
+        <text name="ft_rainKey_whyUnknown" text="az ok nem elerheto" />
+        <text name="ft_rainKey_running" text="MUKODIK" />
+        <text name="ft_rainKey_rainPaused" text="ESO MIATT SZUNETEL" />
+        <text name="ft_rainKey_off" text="ki" />
+        <text name="ft_rainKey_unknownState" text="az erzekelo allapota ismeretlen" />
+        <text name="ft_rainKey_dryResetIn" text="szaraz visszaallas %s mulva" />
+        <text name="ft_rainKey_dryResetPending" text="visszaallas, ha eláll az eso" />
+        <text name="ft_rainKey_nextCheckIn" text="kovetkezo ellenorzes %s" />
+        <text name="ft_rainKey_nextCheck" text="a kovetkezo menetrend-ellenorzeskor indulhat" />
+        <text name="ft_rainKey_playerAction" text="beavatkozas kell: ellenorizze a vizforrast" />
+        <text name="ft_rainKey_collected" text="gyujtott" />
+        <text name="ft_rainKey_trip" text="kuszob" />
+        <text name="ft_rainKey_notifyTitle" text="Ontozes" />
+        <text name="ft_rainKey_notifyPaused" text="A #%s pivot leallt az esoerzekelo miatt" />
+        <text name="ft_rainKey_notifyResumed" text="A #%s pivot a kovetkezo ellenorzeskor ujra indulhat" />
+        <text name="ft_water_header" text="VIZFORRASOK" />
+        <text name="ft_water_unlimited" text="Korlatlan" />
+        <text name="ft_water_hours" text="%.1f / %.1f o" />
+        <text name="ft_water_dry" text="Szaraz" />
+        <text name="ft_water_na" text="Nem elerheto" />
+        <text name="ft_water_none" text="Nincs vizforras ezen a farmon." />
+        <text name="ft_water_source" text="Vizforras" />
+        <text name="ft_water_connected" text="%d csatlakoztatva" />
+        <text name="ft_water_stop_dry" text="Szaraz forras" />
+        <text name="ft_water_stop_nosource" text="Nincs forras" />
     </texts>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="bisa menunggu" />
         <text name="ft_irr_advisory_schedule_covers" text="jadwal mencakup" />
         <text name="ft_irr_advisory_schedule_gap" text="celah jadwal" />
+        <text name="ft_rainKey_unknown" text="tidak diketahui" />
+        <text name="ft_rainKey_mm" text="mm model" />
+        <text name="ft_rainKey_unfitted" text="tanpa sensor hujan" />
+        <text name="ft_rainKey_armed" text="sensor siap" />
+        <text name="ft_rainKey_collecting" text="mengumpulkan hujan" />
+        <text name="ft_rainKey_tripped" text="sensor aktif" />
+        <text name="ft_rainKey_inputUnavail" text="masukan sensor tidak tersedia" />
+        <text name="ft_rainKey_whyTripped" text="berhenti karena sensor hujan aktif" />
+        <text name="ft_rainKey_whyNoInput" text="cuaca tidak terbaca" />
+        <text name="ft_rainKey_whyNoSource" text="tidak ada sumber air" />
+        <text name="ft_rainKey_whyNoPress" text="tidak ada tekanan" />
+        <text name="ft_rainKey_whySchedule" text="di luar jadwal" />
+        <text name="ft_rainKey_whyMaster" text="sakelar utama irigasi mati" />
+        <text name="ft_rainKey_whyUnknown" text="alasan tidak tersedia" />
+        <text name="ft_rainKey_running" text="BERJALAN" />
+        <text name="ft_rainKey_rainPaused" text="JEDA HUJAN" />
+        <text name="ft_rainKey_off" text="mati" />
+        <text name="ft_rainKey_unknownState" text="status sensor tidak diketahui" />
+        <text name="ft_rainKey_dryResetIn" text="reset kering dalam %s" />
+        <text name="ft_rainKey_dryResetPending" text="reset setelah hujan berhenti" />
+        <text name="ft_rainKey_nextCheckIn" text="pemeriksaan jadwal berikutnya %s" />
+        <text name="ft_rainKey_nextCheck" text="siap pada pemeriksaan jadwal berikutnya" />
+        <text name="ft_rainKey_playerAction" text="perlu tindakan: periksa sumber air" />
+        <text name="ft_rainKey_collected" text="terkumpul" />
+        <text name="ft_rainKey_trip" text="ambang" />
+        <text name="ft_rainKey_notifyTitle" text="Irigasi" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s berhenti karena sensor hujan aktif" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s siap lagi pada pemeriksaan jadwal berikutnya" />
+        <text name="ft_water_header" text="SUMBER AIR" />
+        <text name="ft_water_unlimited" text="Tanpa batas" />
+        <text name="ft_water_hours" text="%.1f / %.1f j" />
+        <text name="ft_water_dry" text="Kering" />
+        <text name="ft_water_na" text="Tidak tersedia" />
+        <text name="ft_water_none" text="Tidak ada sumber air di pertanian ini." />
+        <text name="ft_water_source" text="Sumber air" />
+        <text name="ft_water_connected" text="%d terhubung" />
+        <text name="ft_water_stop_dry" text="Sumber kering" />
+        <text name="ft_water_stop_nosource" text="Tidak ada sumber" />
     </texts>
 
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="può attendere" />
         <text name="ft_irr_advisory_schedule_covers" text="programma copre" />
         <text name="ft_irr_advisory_schedule_gap" text="gap di programma" />
+        <text name="ft_rainKey_unknown" text="sconosciuto" />
+        <text name="ft_rainKey_mm" text="mm modellati" />
+        <text name="ft_rainKey_unfitted" text="nessun sensore pioggia" />
+        <text name="ft_rainKey_armed" text="sensore armato" />
+        <text name="ft_rainKey_collecting" text="raccolta pioggia" />
+        <text name="ft_rainKey_tripped" text="sensore scattato" />
+        <text name="ft_rainKey_inputUnavail" text="ingresso sensore non disponibile" />
+        <text name="ft_rainKey_whyTripped" text="fermato perche il sensore pioggia e scattato" />
+        <text name="ft_rainKey_whyNoInput" text="meteo non leggibile" />
+        <text name="ft_rainKey_whyNoSource" text="nessuna fonte d'acqua" />
+        <text name="ft_rainKey_whyNoPress" text="nessuna pressione" />
+        <text name="ft_rainKey_whySchedule" text="fuori programma" />
+        <text name="ft_rainKey_whyMaster" text="interruttore generale irrigazione spento" />
+        <text name="ft_rainKey_whyUnknown" text="motivo non disponibile" />
+        <text name="ft_rainKey_running" text="IN FUNZIONE" />
+        <text name="ft_rainKey_rainPaused" text="PAUSA PIOGGIA" />
+        <text name="ft_rainKey_off" text="spento" />
+        <text name="ft_rainKey_unknownState" text="stato sensore sconosciuto" />
+        <text name="ft_rainKey_dryResetIn" text="reset asciutto tra %s" />
+        <text name="ft_rainKey_dryResetPending" text="reset quando smette di piovere" />
+        <text name="ft_rainKey_nextCheckIn" text="prossimo controllo %s" />
+        <text name="ft_rainKey_nextCheck" text="idoneo al prossimo controllo del programma" />
+        <text name="ft_rainKey_playerAction" text="serve un intervento: controlla la fonte d'acqua" />
+        <text name="ft_rainKey_collected" text="raccolti" />
+        <text name="ft_rainKey_trip" text="soglia" />
+        <text name="ft_rainKey_notifyTitle" text="Irrigazione" />
+        <text name="ft_rainKey_notifyPaused" text="Il pivot #%s si e fermato perche il sensore pioggia e scattato" />
+        <text name="ft_rainKey_notifyResumed" text="Il pivot #%s sara di nuovo idoneo al prossimo controllo" />
+        <text name="ft_water_header" text="FONTI D'ACQUA" />
+        <text name="ft_water_unlimited" text="Illimitato" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Secca" />
+        <text name="ft_water_na" text="Non disponibile" />
+        <text name="ft_water_none" text="Nessuna fonte d'acqua in questa fattoria." />
+        <text name="ft_water_source" text="Fonte d'acqua" />
+        <text name="ft_water_connected" text="%d collegati" />
+        <text name="ft_water_stop_dry" text="Fonte secca" />
+        <text name="ft_water_stop_nosource" text="Nessuna fonte" />
     </texts>
 
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="待てる" />
         <text name="ft_irr_advisory_schedule_covers" text="予定が対応" />
         <text name="ft_irr_advisory_schedule_gap" text="予定の隙間" />
+        <text name="ft_rainKey_unknown" text="不明" />
+        <text name="ft_rainKey_mm" text="モデル化 mm" />
+        <text name="ft_rainKey_unfitted" text="レインセンサー未装着" />
+        <text name="ft_rainKey_armed" text="センサー待機中" />
+        <text name="ft_rainKey_collecting" text="降雨を蓄積中" />
+        <text name="ft_rainKey_tripped" text="センサー作動" />
+        <text name="ft_rainKey_inputUnavail" text="センサー入力なし" />
+        <text name="ft_rainKey_whyTripped" text="レインセンサー作動のため停止" />
+        <text name="ft_rainKey_whyNoInput" text="天候を読み取れません" />
+        <text name="ft_rainKey_whyNoSource" text="水源なし" />
+        <text name="ft_rainKey_whyNoPress" text="圧力なし" />
+        <text name="ft_rainKey_whySchedule" text="スケジュール外" />
+        <text name="ft_rainKey_whyMaster" text="かん水メインスイッチ オフ" />
+        <text name="ft_rainKey_whyUnknown" text="理由不明" />
+        <text name="ft_rainKey_running" text="稼働中" />
+        <text name="ft_rainKey_rainPaused" text="降雨で一時停止" />
+        <text name="ft_rainKey_off" text="停止" />
+        <text name="ft_rainKey_unknownState" text="センサー状態不明" />
+        <text name="ft_rainKey_dryResetIn" text="%s 後に乾燥リセット" />
+        <text name="ft_rainKey_dryResetPending" text="雨がやんだらリセット" />
+        <text name="ft_rainKey_nextCheckIn" text="次のスケジュール確認 %s" />
+        <text name="ft_rainKey_nextCheck" text="次のスケジュール確認時に再開可能" />
+        <text name="ft_rainKey_playerAction" text="要対応: 水源を確認してください" />
+        <text name="ft_rainKey_collected" text="蓄積" />
+        <text name="ft_rainKey_trip" text="しきい値" />
+        <text name="ft_rainKey_notifyTitle" text="かん水" />
+        <text name="ft_rainKey_notifyPaused" text="ピボット #%s がレインセンサーで停止しました" />
+        <text name="ft_rainKey_notifyResumed" text="ピボット #%s は次のスケジュール確認時に再開できます" />
+        <text name="ft_water_header" text="水源" />
+        <text name="ft_water_unlimited" text="無制限" />
+        <text name="ft_water_hours" text="%.1f / %.1f 時間" />
+        <text name="ft_water_dry" text="枯渇" />
+        <text name="ft_water_na" text="利用不可" />
+        <text name="ft_water_none" text="この農場に水源がありません。" />
+        <text name="ft_water_source" text="水源" />
+        <text name="ft_water_connected" text="%d 接続" />
+        <text name="ft_water_stop_dry" text="水源が枯渇" />
+        <text name="ft_water_stop_nosource" text="水源なし" />
     </texts>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="기다릴 수 있음" />
         <text name="ft_irr_advisory_schedule_covers" text="일정이 충당" />
         <text name="ft_irr_advisory_schedule_gap" text="일정 공백" />
+        <text name="ft_rainKey_unknown" text="알 수 없음" />
+        <text name="ft_rainKey_mm" text="모델링 mm" />
+        <text name="ft_rainKey_unfitted" text="레인 센서 미장착" />
+        <text name="ft_rainKey_armed" text="센서 준비됨" />
+        <text name="ft_rainKey_collecting" text="강우 수집 중" />
+        <text name="ft_rainKey_tripped" text="센서 작동됨" />
+        <text name="ft_rainKey_inputUnavail" text="센서 입력 없음" />
+        <text name="ft_rainKey_whyTripped" text="레인 센서가 작동하여 정지됨" />
+        <text name="ft_rainKey_whyNoInput" text="날씨를 읽을 수 없음" />
+        <text name="ft_rainKey_whyNoSource" text="수원 없음" />
+        <text name="ft_rainKey_whyNoPress" text="압력 없음" />
+        <text name="ft_rainKey_whySchedule" text="일정 시간 외" />
+        <text name="ft_rainKey_whyMaster" text="관개 메인 스위치 꺼짐" />
+        <text name="ft_rainKey_whyUnknown" text="사유 없음" />
+        <text name="ft_rainKey_running" text="작동 중" />
+        <text name="ft_rainKey_rainPaused" text="강우 일시정지" />
+        <text name="ft_rainKey_off" text="꺼짐" />
+        <text name="ft_rainKey_unknownState" text="센서 상태 알 수 없음" />
+        <text name="ft_rainKey_dryResetIn" text="%s 후 건조 초기화" />
+        <text name="ft_rainKey_dryResetPending" text="비가 그치면 초기화" />
+        <text name="ft_rainKey_nextCheckIn" text="다음 일정 확인 %s" />
+        <text name="ft_rainKey_nextCheck" text="다음 일정 확인 시 가능" />
+        <text name="ft_rainKey_playerAction" text="조치 필요: 수원을 확인하세요" />
+        <text name="ft_rainKey_collected" text="수집량" />
+        <text name="ft_rainKey_trip" text="기준값" />
+        <text name="ft_rainKey_notifyTitle" text="관개" />
+        <text name="ft_rainKey_notifyPaused" text="피벗 #%s이(가) 레인 센서로 정지했습니다" />
+        <text name="ft_rainKey_notifyResumed" text="피벗 #%s은(는) 다음 일정 확인 시 다시 가능합니다" />
+        <text name="ft_water_header" text="수원" />
+        <text name="ft_water_unlimited" text="무제한" />
+        <text name="ft_water_hours" text="%.1f / %.1f 시간" />
+        <text name="ft_water_dry" text="고갈" />
+        <text name="ft_water_na" text="사용 불가" />
+        <text name="ft_water_none" text="이 농장에 수원이 없습니다." />
+        <text name="ft_water_source" text="수원" />
+        <text name="ft_water_connected" text="%d개 연결됨" />
+        <text name="ft_water_stop_dry" text="수원 고갈" />
+        <text name="ft_water_stop_nosource" text="수원 없음" />
     </texts>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="kan wachten" />
         <text name="ft_irr_advisory_schedule_covers" text="plan dekt" />
         <text name="ft_irr_advisory_schedule_gap" text="planhiaat" />
+        <text name="ft_rainKey_unknown" text="onbekend" />
+        <text name="ft_rainKey_mm" text="mm gemodelleerd" />
+        <text name="ft_rainKey_unfitted" text="geen regensensor" />
+        <text name="ft_rainKey_armed" text="sensor scherp" />
+        <text name="ft_rainKey_collecting" text="regen verzamelen" />
+        <text name="ft_rainKey_tripped" text="sensor geactiveerd" />
+        <text name="ft_rainKey_inputUnavail" text="sensorinvoer niet beschikbaar" />
+        <text name="ft_rainKey_whyTripped" text="gestopt omdat de regensensor is geactiveerd" />
+        <text name="ft_rainKey_whyNoInput" text="weer niet leesbaar" />
+        <text name="ft_rainKey_whyNoSource" text="geen waterbron" />
+        <text name="ft_rainKey_whyNoPress" text="geen druk" />
+        <text name="ft_rainKey_whySchedule" text="buiten het schema" />
+        <text name="ft_rainKey_whyMaster" text="hoofdschakelaar irrigatie uit" />
+        <text name="ft_rainKey_whyUnknown" text="reden niet beschikbaar" />
+        <text name="ft_rainKey_running" text="ACTIEF" />
+        <text name="ft_rainKey_rainPaused" text="REGENPAUZE" />
+        <text name="ft_rainKey_off" text="uit" />
+        <text name="ft_rainKey_unknownState" text="sensorstatus onbekend" />
+        <text name="ft_rainKey_dryResetIn" text="droge reset over %s" />
+        <text name="ft_rainKey_dryResetPending" text="droge reset zodra de regen stopt" />
+        <text name="ft_rainKey_nextCheckIn" text="volgende schemacontrole %s" />
+        <text name="ft_rainKey_nextCheck" text="weer beschikbaar bij de volgende schemacontrole" />
+        <text name="ft_rainKey_playerAction" text="actie nodig: controleer de waterbron" />
+        <text name="ft_rainKey_collected" text="verzameld" />
+        <text name="ft_rainKey_trip" text="drempel" />
+        <text name="ft_rainKey_notifyTitle" text="Irrigatie" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s is gestopt door de regensensor" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s is weer beschikbaar bij de volgende schemacontrole" />
+        <text name="ft_water_header" text="WATERBRONNEN" />
+        <text name="ft_water_unlimited" text="Onbeperkt" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Droog" />
+        <text name="ft_water_na" text="Niet beschikbaar" />
+        <text name="ft_water_none" text="Geen waterbronnen op deze boerderij." />
+        <text name="ft_water_source" text="Waterbron" />
+        <text name="ft_water_connected" text="%d verbonden" />
+        <text name="ft_water_stop_dry" text="Bron droog" />
+        <text name="ft_water_stop_nosource" text="Geen bron" />
     </texts>
 
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="kan vente" />
         <text name="ft_irr_advisory_schedule_covers" text="planen dekker" />
         <text name="ft_irr_advisory_schedule_gap" text="planhull" />
+        <text name="ft_rainKey_unknown" text="ukjent" />
+        <text name="ft_rainKey_mm" text="modellerte mm" />
+        <text name="ft_rainKey_unfitted" text="ingen regnsensor montert" />
+        <text name="ft_rainKey_armed" text="sensor aktivert" />
+        <text name="ft_rainKey_collecting" text="samler regn" />
+        <text name="ft_rainKey_tripped" text="sensor utlost" />
+        <text name="ft_rainKey_inputUnavail" text="sensordata utilgjengelig" />
+        <text name="ft_rainKey_whyTripped" text="stoppet fordi regnsensoren ble utlost" />
+        <text name="ft_rainKey_whyNoInput" text="kan ikke lese vaeret" />
+        <text name="ft_rainKey_whyNoSource" text="ingen vannkilde" />
+        <text name="ft_rainKey_whyNoPress" text="ingen trykk" />
+        <text name="ft_rainKey_whySchedule" text="utenfor planen" />
+        <text name="ft_rainKey_whyMaster" text="hovedbryter for vanning av" />
+        <text name="ft_rainKey_whyUnknown" text="arsak utilgjengelig" />
+        <text name="ft_rainKey_running" text="I DRIFT" />
+        <text name="ft_rainKey_rainPaused" text="REGNPAUSE" />
+        <text name="ft_rainKey_off" text="av" />
+        <text name="ft_rainKey_unknownState" text="sensorstatus ukjent" />
+        <text name="ft_rainKey_dryResetIn" text="torr tilbakestilling om %s" />
+        <text name="ft_rainKey_dryResetPending" text="tilbakestilling nar regnet slutter" />
+        <text name="ft_rainKey_nextCheckIn" text="neste plansjekk %s" />
+        <text name="ft_rainKey_nextCheck" text="klar ved neste plansjekk" />
+        <text name="ft_rainKey_playerAction" text="krever handling: sjekk vannkilden" />
+        <text name="ft_rainKey_collected" text="samlet" />
+        <text name="ft_rainKey_trip" text="terskel" />
+        <text name="ft_rainKey_notifyTitle" text="Vanning" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s stoppet av regnsensoren" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s er klar igjen ved neste plansjekk" />
+        <text name="ft_water_header" text="VANNKILDER" />
+        <text name="ft_water_unlimited" text="Ubegrenset" />
+        <text name="ft_water_hours" text="%.1f / %.1f t" />
+        <text name="ft_water_dry" text="Torr" />
+        <text name="ft_water_na" text="Utilgjengelig" />
+        <text name="ft_water_none" text="Ingen vannkilder pa denne garden." />
+        <text name="ft_water_source" text="Vannkilde" />
+        <text name="ft_water_connected" text="%d tilkoblet" />
+        <text name="ft_water_stop_dry" text="Kilden er torr" />
+        <text name="ft_water_stop_nosource" text="Ingen kilde" />
     </texts>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="może poczekać" />
         <text name="ft_irr_advisory_schedule_covers" text="plan pokrywa" />
         <text name="ft_irr_advisory_schedule_gap" text="luka w planie" />
+        <text name="ft_rainKey_unknown" text="nieznany" />
+        <text name="ft_rainKey_mm" text="mm modelowane" />
+        <text name="ft_rainKey_unfitted" text="brak czujnika deszczu" />
+        <text name="ft_rainKey_armed" text="czujnik uzbrojony" />
+        <text name="ft_rainKey_collecting" text="zbieranie deszczu" />
+        <text name="ft_rainKey_tripped" text="czujnik zadzialal" />
+        <text name="ft_rainKey_inputUnavail" text="brak odczytu czujnika" />
+        <text name="ft_rainKey_whyTripped" text="zatrzymano, bo czujnik deszczu zadzialal" />
+        <text name="ft_rainKey_whyNoInput" text="nie mozna odczytac pogody" />
+        <text name="ft_rainKey_whyNoSource" text="brak zrodla wody" />
+        <text name="ft_rainKey_whyNoPress" text="brak cisnienia" />
+        <text name="ft_rainKey_whySchedule" text="poza harmonogramem" />
+        <text name="ft_rainKey_whyMaster" text="glowny wylacznik nawadniania wylaczony" />
+        <text name="ft_rainKey_whyUnknown" text="powod niedostepny" />
+        <text name="ft_rainKey_running" text="PRACUJE" />
+        <text name="ft_rainKey_rainPaused" text="PAUZA DESZCZOWA" />
+        <text name="ft_rainKey_off" text="wylaczony" />
+        <text name="ft_rainKey_unknownState" text="stan czujnika nieznany" />
+        <text name="ft_rainKey_dryResetIn" text="reset po %s suszy" />
+        <text name="ft_rainKey_dryResetPending" text="reset, gdy deszcz ustanie" />
+        <text name="ft_rainKey_nextCheckIn" text="nastepne sprawdzenie %s" />
+        <text name="ft_rainKey_nextCheck" text="gotowy przy nastepnym sprawdzeniu harmonogramu" />
+        <text name="ft_rainKey_playerAction" text="wymaga dzialania: sprawdz zrodlo wody" />
+        <text name="ft_rainKey_collected" text="zebrano" />
+        <text name="ft_rainKey_trip" text="prog" />
+        <text name="ft_rainKey_notifyTitle" text="Nawadnianie" />
+        <text name="ft_rainKey_notifyPaused" text="Deszczownia #%s zatrzymana przez czujnik deszczu" />
+        <text name="ft_rainKey_notifyResumed" text="Deszczownia #%s bedzie gotowa przy nastepnym sprawdzeniu" />
+        <text name="ft_water_header" text="ZRODLA WODY" />
+        <text name="ft_water_unlimited" text="Bez limitu" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Sucho" />
+        <text name="ft_water_na" text="Niedostepne" />
+        <text name="ft_water_none" text="Brak zrodel wody w tym gospodarstwie." />
+        <text name="ft_water_source" text="Zrodlo wody" />
+        <text name="ft_water_connected" text="%d podlaczonych" />
+        <text name="ft_water_stop_dry" text="Zrodlo suche" />
+        <text name="ft_water_stop_nosource" text="Brak zrodla" />
     </texts>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="pode esperar" />
         <text name="ft_irr_advisory_schedule_covers" text="o plano cobre" />
         <text name="ft_irr_advisory_schedule_gap" text="lacuna no plano" />
+        <text name="ft_rainKey_unknown" text="desconhecido" />
+        <text name="ft_rainKey_mm" text="mm modelados" />
+        <text name="ft_rainKey_unfitted" text="sem sensor de chuva" />
+        <text name="ft_rainKey_armed" text="sensor armado" />
+        <text name="ft_rainKey_collecting" text="a recolher chuva" />
+        <text name="ft_rainKey_tripped" text="sensor disparado" />
+        <text name="ft_rainKey_inputUnavail" text="entrada do sensor indisponivel" />
+        <text name="ft_rainKey_whyTripped" text="parado porque o sensor de chuva disparou" />
+        <text name="ft_rainKey_whyNoInput" text="nao e possivel ler o tempo" />
+        <text name="ft_rainKey_whyNoSource" text="sem fonte de agua" />
+        <text name="ft_rainKey_whyNoPress" text="sem pressao" />
+        <text name="ft_rainKey_whySchedule" text="fora do horario" />
+        <text name="ft_rainKey_whyMaster" text="interruptor geral de rega desligado" />
+        <text name="ft_rainKey_whyUnknown" text="motivo indisponivel" />
+        <text name="ft_rainKey_running" text="EM FUNCIONAMENTO" />
+        <text name="ft_rainKey_rainPaused" text="PAUSA POR CHUVA" />
+        <text name="ft_rainKey_off" text="desligado" />
+        <text name="ft_rainKey_unknownState" text="estado do sensor desconhecido" />
+        <text name="ft_rainKey_dryResetIn" text="reinicio seco em %s" />
+        <text name="ft_rainKey_dryResetPending" text="reinicio quando a chuva parar" />
+        <text name="ft_rainKey_nextCheckIn" text="proxima verificacao %s" />
+        <text name="ft_rainKey_nextCheck" text="elegivel na proxima verificacao do horario" />
+        <text name="ft_rainKey_playerAction" text="requer acao: verificar a fonte de agua" />
+        <text name="ft_rainKey_collected" text="recolhido" />
+        <text name="ft_rainKey_trip" text="limite" />
+        <text name="ft_rainKey_notifyTitle" text="Rega" />
+        <text name="ft_rainKey_notifyPaused" text="O pivo #%s parou porque o sensor de chuva disparou" />
+        <text name="ft_rainKey_notifyResumed" text="O pivo #%s fica novamente elegivel na proxima verificacao" />
+        <text name="ft_water_header" text="FONTES DE AGUA" />
+        <text name="ft_water_unlimited" text="Ilimitado" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Seca" />
+        <text name="ft_water_na" text="Indisponivel" />
+        <text name="ft_water_none" text="Sem fontes de agua nesta quinta." />
+        <text name="ft_water_source" text="Fonte de agua" />
+        <text name="ft_water_connected" text="%d ligados" />
+        <text name="ft_water_stop_dry" text="Fonte seca" />
+        <text name="ft_water_stop_nosource" text="Sem fonte" />
     </texts>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="poate aștepta" />
         <text name="ft_irr_advisory_schedule_covers" text="planul acoperă" />
         <text name="ft_irr_advisory_schedule_gap" text="gol de plan" />
+        <text name="ft_rainKey_unknown" text="necunoscut" />
+        <text name="ft_rainKey_mm" text="mm modelati" />
+        <text name="ft_rainKey_unfitted" text="fara senzor de ploaie" />
+        <text name="ft_rainKey_armed" text="senzor armat" />
+        <text name="ft_rainKey_collecting" text="colecteaza ploaie" />
+        <text name="ft_rainKey_tripped" text="senzor declansat" />
+        <text name="ft_rainKey_inputUnavail" text="intrare senzor indisponibila" />
+        <text name="ft_rainKey_whyTripped" text="oprit deoarece senzorul de ploaie s-a declansat" />
+        <text name="ft_rainKey_whyNoInput" text="vremea nu poate fi citita" />
+        <text name="ft_rainKey_whyNoSource" text="fara sursa de apa" />
+        <text name="ft_rainKey_whyNoPress" text="fara presiune" />
+        <text name="ft_rainKey_whySchedule" text="in afara programului" />
+        <text name="ft_rainKey_whyMaster" text="intrerupatorul general de irigare este oprit" />
+        <text name="ft_rainKey_whyUnknown" text="motiv indisponibil" />
+        <text name="ft_rainKey_running" text="IN FUNCTIUNE" />
+        <text name="ft_rainKey_rainPaused" text="PAUZA DE PLOAIE" />
+        <text name="ft_rainKey_off" text="oprit" />
+        <text name="ft_rainKey_unknownState" text="stare senzor necunoscuta" />
+        <text name="ft_rainKey_dryResetIn" text="resetare uscata in %s" />
+        <text name="ft_rainKey_dryResetPending" text="resetare cand se opreste ploaia" />
+        <text name="ft_rainKey_nextCheckIn" text="urmatoarea verificare %s" />
+        <text name="ft_rainKey_nextCheck" text="eligibil la urmatoarea verificare a programului" />
+        <text name="ft_rainKey_playerAction" text="necesita actiune: verificati sursa de apa" />
+        <text name="ft_rainKey_collected" text="colectat" />
+        <text name="ft_rainKey_trip" text="prag" />
+        <text name="ft_rainKey_notifyTitle" text="Irigare" />
+        <text name="ft_rainKey_notifyPaused" text="Pivotul #%s s-a oprit din cauza senzorului de ploaie" />
+        <text name="ft_rainKey_notifyResumed" text="Pivotul #%s va fi eligibil la urmatoarea verificare" />
+        <text name="ft_water_header" text="SURSE DE APA" />
+        <text name="ft_water_unlimited" text="Nelimitat" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Uscata" />
+        <text name="ft_water_na" text="Indisponibil" />
+        <text name="ft_water_none" text="Nicio sursa de apa la aceasta ferma." />
+        <text name="ft_water_source" text="Sursa de apa" />
+        <text name="ft_water_connected" text="%d conectate" />
+        <text name="ft_water_stop_dry" text="Sursa uscata" />
+        <text name="ft_water_stop_nosource" text="Fara sursa" />
     </texts>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -2589,6 +2589,44 @@
         <text name="ft_irr_call_can_hold" text="можно подождать" />
         <text name="ft_irr_advisory_schedule_covers" text="график покрывает" />
         <text name="ft_irr_advisory_schedule_gap" text="пробел в графике" />
+        <text name="ft_rainKey_unknown" text="неизвестно" />
+        <text name="ft_rainKey_mm" text="мм расчетных" />
+        <text name="ft_rainKey_unfitted" text="датчик дождя не установлен" />
+        <text name="ft_rainKey_armed" text="датчик готов" />
+        <text name="ft_rainKey_collecting" text="накопление дождя" />
+        <text name="ft_rainKey_tripped" text="датчик сработал" />
+        <text name="ft_rainKey_inputUnavail" text="данные датчика недоступны" />
+        <text name="ft_rainKey_whyTripped" text="остановлено: сработал датчик дождя" />
+        <text name="ft_rainKey_whyNoInput" text="погода недоступна" />
+        <text name="ft_rainKey_whyNoSource" text="нет источника воды" />
+        <text name="ft_rainKey_whyNoPress" text="нет давления" />
+        <text name="ft_rainKey_whySchedule" text="вне расписания" />
+        <text name="ft_rainKey_whyMaster" text="главный выключатель полива выключен" />
+        <text name="ft_rainKey_whyUnknown" text="причина недоступна" />
+        <text name="ft_rainKey_running" text="РАБОТАЕТ" />
+        <text name="ft_rainKey_rainPaused" text="ПАУЗА ПО ДОЖДЮ" />
+        <text name="ft_rainKey_off" text="выкл" />
+        <text name="ft_rainKey_unknownState" text="состояние датчика неизвестно" />
+        <text name="ft_rainKey_dryResetIn" text="сухой сброс через %s" />
+        <text name="ft_rainKey_dryResetPending" text="сброс после окончания дождя" />
+        <text name="ft_rainKey_nextCheckIn" text="следующая проверка %s" />
+        <text name="ft_rainKey_nextCheck" text="будет доступен при следующей проверке расписания" />
+        <text name="ft_rainKey_playerAction" text="нужно действие: проверьте источник воды" />
+        <text name="ft_rainKey_collected" text="накоплено" />
+        <text name="ft_rainKey_trip" text="порог" />
+        <text name="ft_rainKey_notifyTitle" text="Полив" />
+        <text name="ft_rainKey_notifyPaused" text="Дождеватель #%s остановлен датчиком дождя" />
+        <text name="ft_rainKey_notifyResumed" text="Дождеватель #%s снова доступен при следующей проверке" />
+        <text name="ft_water_header" text="ИСТОЧНИКИ ВОДЫ" />
+        <text name="ft_water_unlimited" text="Без ограничений" />
+        <text name="ft_water_hours" text="%.1f / %.1f ч" />
+        <text name="ft_water_dry" text="Сухой" />
+        <text name="ft_water_na" text="Недоступно" />
+        <text name="ft_water_none" text="На этой ферме нет источников воды." />
+        <text name="ft_water_source" text="Источник воды" />
+        <text name="ft_water_connected" text="%d подключено" />
+        <text name="ft_water_stop_dry" text="Источник сухой" />
+        <text name="ft_water_stop_nosource" text="Нет источника" />
     </texts>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="kan vänta" />
         <text name="ft_irr_advisory_schedule_covers" text="planen täcker" />
         <text name="ft_irr_advisory_schedule_gap" text="planlucka" />
+        <text name="ft_rainKey_unknown" text="okant" />
+        <text name="ft_rainKey_mm" text="modellerade mm" />
+        <text name="ft_rainKey_unfitted" text="ingen regnsensor monterad" />
+        <text name="ft_rainKey_armed" text="sensor aktiverad" />
+        <text name="ft_rainKey_collecting" text="samlar regn" />
+        <text name="ft_rainKey_tripped" text="sensor utlost" />
+        <text name="ft_rainKey_inputUnavail" text="sensordata otillgangligt" />
+        <text name="ft_rainKey_whyTripped" text="stoppad eftersom regnsensorn utlostes" />
+        <text name="ft_rainKey_whyNoInput" text="kan inte lasa vadret" />
+        <text name="ft_rainKey_whyNoSource" text="ingen vattenkalla" />
+        <text name="ft_rainKey_whyNoPress" text="inget tryck" />
+        <text name="ft_rainKey_whySchedule" text="utanfor schemat" />
+        <text name="ft_rainKey_whyMaster" text="huvudbrytare for bevattning av" />
+        <text name="ft_rainKey_whyUnknown" text="orsak otillganglig" />
+        <text name="ft_rainKey_running" text="I DRIFT" />
+        <text name="ft_rainKey_rainPaused" text="REGNPAUS" />
+        <text name="ft_rainKey_off" text="av" />
+        <text name="ft_rainKey_unknownState" text="sensorstatus okand" />
+        <text name="ft_rainKey_dryResetIn" text="torr aterstallning om %s" />
+        <text name="ft_rainKey_dryResetPending" text="aterstallning nar regnet slutar" />
+        <text name="ft_rainKey_nextCheckIn" text="nasta schemakontroll %s" />
+        <text name="ft_rainKey_nextCheck" text="redo vid nasta schemakontroll" />
+        <text name="ft_rainKey_playerAction" text="kraver atgard: kontrollera vattenkallan" />
+        <text name="ft_rainKey_collected" text="samlat" />
+        <text name="ft_rainKey_trip" text="troskel" />
+        <text name="ft_rainKey_notifyTitle" text="Bevattning" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s stoppades av regnsensorn" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s ar redo igen vid nasta schemakontroll" />
+        <text name="ft_water_header" text="VATTENKALLOR" />
+        <text name="ft_water_unlimited" text="Obegransat" />
+        <text name="ft_water_hours" text="%.1f / %.1f h" />
+        <text name="ft_water_dry" text="Torr" />
+        <text name="ft_water_na" text="Otillgangligt" />
+        <text name="ft_water_none" text="Inga vattenkallor pa denna gard." />
+        <text name="ft_water_source" text="Vattenkalla" />
+        <text name="ft_water_connected" text="%d anslutna" />
+        <text name="ft_water_stop_dry" text="Kallan ar torr" />
+        <text name="ft_water_stop_nosource" text="Ingen kalla" />
     </texts>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -2548,6 +2548,44 @@
         <text name="ft_irr_call_can_hold" text="bekleyebilir" />
         <text name="ft_irr_advisory_schedule_covers" text="plan karşılıyor" />
         <text name="ft_irr_advisory_schedule_gap" text="plan boşluğu" />
+        <text name="ft_rainKey_unknown" text="bilinmiyor" />
+        <text name="ft_rainKey_mm" text="modellenen mm" />
+        <text name="ft_rainKey_unfitted" text="yagmur sensoru takili degil" />
+        <text name="ft_rainKey_armed" text="sensor hazir" />
+        <text name="ft_rainKey_collecting" text="yagmur topluyor" />
+        <text name="ft_rainKey_tripped" text="sensor devreye girdi" />
+        <text name="ft_rainKey_inputUnavail" text="sensor verisi yok" />
+        <text name="ft_rainKey_whyTripped" text="yagmur sensoru devreye girdigi icin durduruldu" />
+        <text name="ft_rainKey_whyNoInput" text="hava durumu okunamiyor" />
+        <text name="ft_rainKey_whyNoSource" text="su kaynagi yok" />
+        <text name="ft_rainKey_whyNoPress" text="basinc yok" />
+        <text name="ft_rainKey_whySchedule" text="program disinda" />
+        <text name="ft_rainKey_whyMaster" text="sulama ana salteri kapali" />
+        <text name="ft_rainKey_whyUnknown" text="neden bilinmiyor" />
+        <text name="ft_rainKey_running" text="CALISIYOR" />
+        <text name="ft_rainKey_rainPaused" text="YAGMUR MOLASI" />
+        <text name="ft_rainKey_off" text="kapali" />
+        <text name="ft_rainKey_unknownState" text="sensor durumu bilinmiyor" />
+        <text name="ft_rainKey_dryResetIn" text="kuru sifirlama %s sonra" />
+        <text name="ft_rainKey_dryResetPending" text="yagmur dinince sifirlanir" />
+        <text name="ft_rainKey_nextCheckIn" text="sonraki program kontrolu %s" />
+        <text name="ft_rainKey_nextCheck" text="sonraki program kontrolunde uygun" />
+        <text name="ft_rainKey_playerAction" text="islem gerekli: su kaynagini kontrol edin" />
+        <text name="ft_rainKey_collected" text="toplanan" />
+        <text name="ft_rainKey_trip" text="esik" />
+        <text name="ft_rainKey_notifyTitle" text="Sulama" />
+        <text name="ft_rainKey_notifyPaused" text="#%s pivot yagmur sensoru nedeniyle durdu" />
+        <text name="ft_rainKey_notifyResumed" text="#%s pivot sonraki program kontrolunde tekrar uygun" />
+        <text name="ft_water_header" text="SU KAYNAKLARI" />
+        <text name="ft_water_unlimited" text="Sinirsiz" />
+        <text name="ft_water_hours" text="%.1f / %.1f sa" />
+        <text name="ft_water_dry" text="Kuru" />
+        <text name="ft_water_na" text="Kullanilamiyor" />
+        <text name="ft_water_none" text="Bu ciftlikte su kaynagi yok." />
+        <text name="ft_water_source" text="Su kaynagi" />
+        <text name="ft_water_connected" text="%d bagli" />
+        <text name="ft_water_stop_dry" text="Kaynak kuru" />
+        <text name="ft_water_stop_nosource" text="Kaynak yok" />
     </texts>
 
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="можна почекати" />
         <text name="ft_irr_advisory_schedule_covers" text="графік покриває" />
         <text name="ft_irr_advisory_schedule_gap" text="прогалина в графіку" />
+        <text name="ft_rainKey_unknown" text="невідомо" />
+        <text name="ft_rainKey_mm" text="мм розрахункових" />
+        <text name="ft_rainKey_unfitted" text="датчик дощу не встановлено" />
+        <text name="ft_rainKey_armed" text="датчик готовий" />
+        <text name="ft_rainKey_collecting" text="накопичення дощу" />
+        <text name="ft_rainKey_tripped" text="датчик спрацював" />
+        <text name="ft_rainKey_inputUnavail" text="дані датчика недоступні" />
+        <text name="ft_rainKey_whyTripped" text="зупинено: спрацював датчик дощу" />
+        <text name="ft_rainKey_whyNoInput" text="погода недоступна" />
+        <text name="ft_rainKey_whyNoSource" text="немає джерела води" />
+        <text name="ft_rainKey_whyNoPress" text="немає тиску" />
+        <text name="ft_rainKey_whySchedule" text="поза розкладом" />
+        <text name="ft_rainKey_whyMaster" text="головний вимикач поливу вимкнено" />
+        <text name="ft_rainKey_whyUnknown" text="причина недоступна" />
+        <text name="ft_rainKey_running" text="ПРАЦЮЄ" />
+        <text name="ft_rainKey_rainPaused" text="ПАУЗА ЧЕРЕЗ ДОЩ" />
+        <text name="ft_rainKey_off" text="вимк" />
+        <text name="ft_rainKey_unknownState" text="стан датчика невідомий" />
+        <text name="ft_rainKey_dryResetIn" text="сухе скидання через %s" />
+        <text name="ft_rainKey_dryResetPending" text="скидання після припинення дощу" />
+        <text name="ft_rainKey_nextCheckIn" text="наступна перевірка %s" />
+        <text name="ft_rainKey_nextCheck" text="буде доступний під час наступної перевірки розкладу" />
+        <text name="ft_rainKey_playerAction" text="потрібна дія: перевірте джерело води" />
+        <text name="ft_rainKey_collected" text="накопичено" />
+        <text name="ft_rainKey_trip" text="поріг" />
+        <text name="ft_rainKey_notifyTitle" text="Полив" />
+        <text name="ft_rainKey_notifyPaused" text="Дощувач #%s зупинено датчиком дощу" />
+        <text name="ft_rainKey_notifyResumed" text="Дощувач #%s знову доступний під час наступної перевірки" />
+        <text name="ft_water_header" text="ДЖЕРЕЛА ВОДИ" />
+        <text name="ft_water_unlimited" text="Без обмежень" />
+        <text name="ft_water_hours" text="%.1f / %.1f год" />
+        <text name="ft_water_dry" text="Сухе" />
+        <text name="ft_water_na" text="Недоступно" />
+        <text name="ft_water_none" text="На цій фермі немає джерел води." />
+        <text name="ft_water_source" text="Джерело води" />
+        <text name="ft_water_connected" text="%d підключено" />
+        <text name="ft_water_stop_dry" text="Джерело сухе" />
+        <text name="ft_water_stop_nosource" text="Немає джерела" />
     </texts>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -2547,6 +2547,44 @@
         <text name="ft_irr_call_can_hold" text="có thể chờ" />
         <text name="ft_irr_advisory_schedule_covers" text="lịch bao phủ" />
         <text name="ft_irr_advisory_schedule_gap" text="lỗ hổng lịch" />
+        <text name="ft_rainKey_unknown" text="không rõ" />
+        <text name="ft_rainKey_mm" text="mm mô phỏng" />
+        <text name="ft_rainKey_unfitted" text="chưa lắp cảm biến mưa" />
+        <text name="ft_rainKey_armed" text="cảm biến sẵn sàng" />
+        <text name="ft_rainKey_collecting" text="đang thu nước mưa" />
+        <text name="ft_rainKey_tripped" text="cảm biến đã kích hoạt" />
+        <text name="ft_rainKey_inputUnavail" text="không đọc được cảm biến" />
+        <text name="ft_rainKey_whyTripped" text="dừng vì cảm biến mưa đã kích hoạt" />
+        <text name="ft_rainKey_whyNoInput" text="không đọc được thời tiết" />
+        <text name="ft_rainKey_whyNoSource" text="không có nguồn nước" />
+        <text name="ft_rainKey_whyNoPress" text="không có áp lực" />
+        <text name="ft_rainKey_whySchedule" text="ngoài lịch trình" />
+        <text name="ft_rainKey_whyMaster" text="công tắc tưới chính đang tắt" />
+        <text name="ft_rainKey_whyUnknown" text="không rõ lý do" />
+        <text name="ft_rainKey_running" text="ĐANG CHẠY" />
+        <text name="ft_rainKey_rainPaused" text="TẠM DỪNG DO MƯA" />
+        <text name="ft_rainKey_off" text="tắt" />
+        <text name="ft_rainKey_unknownState" text="không rõ trạng thái cảm biến" />
+        <text name="ft_rainKey_dryResetIn" text="đặt lại khô sau %s" />
+        <text name="ft_rainKey_dryResetPending" text="đặt lại khi tạnh mưa" />
+        <text name="ft_rainKey_nextCheckIn" text="lần kiểm tra lịch kế tiếp %s" />
+        <text name="ft_rainKey_nextCheck" text="đủ điều kiện ở lần kiểm tra lịch kế tiếp" />
+        <text name="ft_rainKey_playerAction" text="cần xử lý: kiểm tra nguồn nước" />
+        <text name="ft_rainKey_collected" text="đã thu" />
+        <text name="ft_rainKey_trip" text="ngưỡng" />
+        <text name="ft_rainKey_notifyTitle" text="Tưới tiêu" />
+        <text name="ft_rainKey_notifyPaused" text="Pivot #%s đã dừng vì cảm biến mưa" />
+        <text name="ft_rainKey_notifyResumed" text="Pivot #%s sẽ hoạt động lại ở lần kiểm tra lịch kế tiếp" />
+        <text name="ft_water_header" text="NGUON NUOC" />
+        <text name="ft_water_unlimited" text="Khong gioi han" />
+        <text name="ft_water_hours" text="%.1f / %.1f gio" />
+        <text name="ft_water_dry" text="Can" />
+        <text name="ft_water_na" text="Khong co san" />
+        <text name="ft_water_none" text="Nong trai nay khong co nguon nuoc." />
+        <text name="ft_water_source" text="Nguon nuoc" />
+        <text name="ft_water_connected" text="%d ket noi" />
+        <text name="ft_water_stop_dry" text="Nguon can" />
+        <text name="ft_water_stop_nosource" text="Khong co nguon" />
     </texts>
 
 


### PR DESCRIPTION
## Summary
- Irrigation Suite Operations now paints rain-key state from Crop Stress (fitted / collecting / tripped / paused / unfitted) instead of leaving that line blank on the shared development tablet.
- Same page also lists this farm's water sources with remaining irrigation hours (or unlimited / dry / not available) using the Crop Stress water-source getter.
- Tablet notifies once when a pivot enters or leaves rain pause. A join while already paused stays quiet. Accumulator progress does not notify.
- Strings added in all 26 locale files. Version 2.6.0.7. Dairy tablet work is not in this pull request.

## Pairing
Crop Stress rain-key engine and finite-water engine are already on development (merged 2026-09-01). This is the Farm Tablet presentation half Wizard playtested locally.

## Test plan
- [ ] Open Farm Tablet Irrigation Suite on a farm that owns a pivot.
- [ ] Confirm rain-key line is honest: unfitted when no key, paused only after a real trip, never a fake rain pause.
- [ ] Confirm WATER SOURCES lists this farm only, with hours or unlimited/dry.
- [ ] Confirm a rain-pause edge notifies once, and a join mid-pause does not.
- [ ] Confirm older Crop Stress without the water getter still loads (hours omit, rain-key still uses the systems snapshot).
- [ ] Dedicated two-player not claimed in this PR.