### PR TITLE
Dairy app: herd and tank breed records for this farm

### DIFF
--- a/src/apps/DairyApp.lua
+++ b/src/apps/DairyApp.lua
@@ -4,6 +4,8 @@
 -- Read-only barn cards from DairyCoreManager:getBarnRows().
 -- Shows only fields the live API returns - no invented litres/collection.
 -- Handle: g_currentMission.dairyCoreManager or getfenv(0)["g_dairyCoreManager"]
+-- DC-27 (BUILD 21:48): HERD NOW / MILK IN TANK sections per card from the server's breed
+-- surface (version 1, strict local farm via FT_DataProvider:getPlayerFarmIdStrict).
 -- =========================================================
 
 local function _dairyMgr()
@@ -38,6 +40,205 @@ local function tierColor(tier)
     return FT.C.TEXT_DIM
 end
 
+-- =========================================================
+-- DC-27 (BUILD 21:48): breed surfaces, presentation only.
+-- =========================================================
+-- Two clocks per barn card. HERD NOW is the milking headcount standing in the barn today,
+-- by breed. MILK IN TANK is the stored milk by the breeds that produced it, with unknown
+-- milk named as unknown. A new herd beside old milk is correct. Both are server records
+-- DairyCoreManager already put on the row; nothing here reads local animals or Storage,
+-- and no breed is scored, ranked or priced.
+local BREED_VERSION = 1
+local UNKNOWN_TOKEN = "UNKNOWN"
+
+--- Strict local farm id via the DataProvider getter (positive number or nil, never 1).
+local function playerFarmIdStrict()
+    if FT_DataProvider ~= nil and type(FT_DataProvider.getPlayerFarmIdStrict) == "function" then
+        local ok, id = pcall(function() return FT_DataProvider:getPlayerFarmIdStrict() end)
+        if ok and type(id) == "number" and id > 0 then return id end
+    end
+    return nil
+end
+
+--- A record is painted only when the server says it is available. Anything else is a state.
+local function breedRecordLive(rec)
+    return type(rec) == "table" and rec.available == true and rec.trust == "server"
+end
+
+local function breedRecordReason(rec)
+    if type(rec) ~= "table" then return "SNAPSHOT_INVALID" end
+    if rec.available == false and type(rec.reason) == "string" and rec.reason ~= "" then
+        return rec.reason
+    end
+    return "SNAPSHOT_INVALID"
+end
+
+local function breedStateLabel(reason)
+    local r = tostring(reason or "")
+    if r == "WAITING_FOR_SERVER" then
+        return FT.l10n("ft_dairy_breed_waiting_server", "Waiting for server")
+    elseif r == "WAITING_FOR_PLAYER_FARM" then
+        return FT.l10n("ft_dairy_breed_waiting_farm", "Waiting for player farm")
+    elseif r == "UNRESOLVED_FILLTYPE" then
+        return FT.l10n("ft_dairy_breed_filltype_unresolved", "Fill type unresolved")
+    elseif r == "NO_INTERNAL_STORAGE" then
+        return FT.l10n("ft_dairy_breed_storage_missing", "No internal storage")
+    elseif r == "NON_SINGLE_STORAGE_ROUTE" then
+        return FT.l10n("ft_dairy_breed_route_unavailable", "Tank route unavailable")
+    elseif r == "HERD_UNRESOLVED" then
+        return FT.l10n("ft_dairy_breed_herd_unresolved", "Herd unreadable")
+    end
+    return FT.l10n("ft_dairy_breed_snapshot_invalid", "Snapshot invalid")
+end
+
+--- Breed label: the subtype's own fill type title (the game's name for the breed), else a
+--- fill type by that name, else the raw token. The UNKNOWN token is localized.
+local function breedLabel(key)
+    local k = tostring(key or "")
+    if k == "" or k == UNKNOWN_TOKEN then
+        return FT.l10n("ft_dairy_breed_unknown", "unknown")
+    end
+    local as = g_currentMission ~= nil and g_currentMission.animalSystem or nil
+    if as ~= nil and type(as.getSubTypeByName) == "function" and g_fillTypeManager ~= nil
+        and type(g_fillTypeManager.getFillTypeTitleByIndex) == "function" then
+        local ok, st = pcall(function() return as:getSubTypeByName(k) end)
+        if ok and type(st) == "table" and st.fillTypeIndex ~= nil then
+            local ok2, title = pcall(function()
+                return g_fillTypeManager:getFillTypeTitleByIndex(st.fillTypeIndex)
+            end)
+            if ok2 and type(title) == "string" and title ~= "" then return title end
+        end
+    end
+    if g_fillTypeManager ~= nil and type(g_fillTypeManager.getFillTypeByName) == "function" then
+        local ok, ft = pcall(function() return g_fillTypeManager:getFillTypeByName(k) end)
+        if ok and type(ft) == "table" and type(ft.title) == "string" and ft.title ~= "" then
+            return ft.title
+        end
+    end
+    return k
+end
+
+local function fillTypeLabel(name)
+    local n = tostring(name or "")
+    if g_fillTypeManager ~= nil and type(g_fillTypeManager.getFillTypeByName) == "function" then
+        local ok, ft = pcall(function() return g_fillTypeManager:getFillTypeByName(n) end)
+        if ok and type(ft) == "table" and type(ft.title) == "string" and ft.title ~= "" then
+            return ft.title
+        end
+    end
+    return n
+end
+
+local function pct(f)
+    return math.floor((tonumber(f) or 0) * 100 + 0.5)
+end
+
+local function litresText(l)
+    return FT.l10nFormat("ft_dairy_breed_litres", "%d L", math.floor((tonumber(l) or 0) + 0.5))
+end
+
+--- Shares sorted for display: share descending, then name; unknown after an equal share.
+local function sortedShares(fractions, unknownShare)
+    local list = {}
+    if type(fractions) == "table" then
+        for k, f in pairs(fractions) do
+            local v = tonumber(f) or 0
+            if v > 0 then
+                local key = tostring(k)
+                list[#list + 1] = { key = key, frac = v, unknown = (key == UNKNOWN_TOKEN) }
+            end
+        end
+    end
+    local u = tonumber(unknownShare) or 0
+    if u > 0 then
+        list[#list + 1] = { key = UNKNOWN_TOKEN, frac = u, unknown = true }
+    end
+    table.sort(list, function(a, b)
+        if a.frac ~= b.frac then return a.frac > b.frac end
+        if a.unknown ~= b.unknown then return not a.unknown end
+        return a.key < b.key
+    end)
+    return list
+end
+
+--- The barn's tracked milk fill types, MILK first, then by name.
+local function milkFillTypeNames(prov)
+    local names = {}
+    if type(prov) == "table" then
+        for k, _ in pairs(prov) do names[#names + 1] = tostring(k) end
+    end
+    table.sort(names, function(a, b)
+        if (a == "MILK") ~= (b == "MILK") then return a == "MILK" end
+        return a < b
+    end)
+    return names
+end
+
+--- The breed rows for one card as { label, value, color } triples in draw order. Every
+--- breed and every tracked fill type is listed; unknown milk is a named row, never a gap.
+local function breedCardRows(row)
+    local out = {}
+    local function add(label, value, color)
+        out[#out + 1] = { label, value, color }
+    end
+    if row.breedSurfaceVersion ~= BREED_VERSION then
+        add(FT.l10n("ft_dairy_breed_help_title", "BREED RECORDS"),
+            FT.l10n("ft_dairy_breed_update_required", "Update required"), FT.C.WARNING)
+        return out
+    end
+
+    local herdLabel = FT.l10n("ft_dairy_breed_herd", "HERD NOW")
+    local h = row.herdBreedComposition
+    if breedRecordLive(h) then
+        local total = math.floor((tonumber(h.totalMilkingHeadcount) or 0) + 0.5)
+        local src = h.sourceMode == "REALISTIC_LIVESTOCK"
+            and FT.l10n("ft_dairy_breed_source_rl", "Realistic Livestock count")
+            or FT.l10n("ft_dairy_breed_source_standard", "standard count")
+        add(herdLabel, string.format("%s (%s)",
+            FT.l10nFormat("ft_dairy_breed_head", "%d head", total), src), FT.C.TEXT_NORMAL)
+        for _, e in ipairs(sortedShares(h.fractions, nil)) do
+            local n = tonumber(type(h.counts) == "table" and h.counts[e.key]) or 0
+            add("  " .. breedLabel(e.key), string.format("%d (%d%%)", math.floor(n + 0.5), pct(e.frac)),
+                e.unknown and FT.C.TEXT_DIM or FT.C.TEXT_NORMAL)
+        end
+    else
+        add(herdLabel, breedStateLabel(breedRecordReason(h)), FT.C.INFO)
+    end
+
+    local milkLabel = FT.l10n("ft_dairy_breed_milk", "MILK IN TANK")
+    local prov = row.milkBreedProvenance
+    local names = milkFillTypeNames(prov)
+    if #names == 0 then
+        add(milkLabel, breedStateLabel("SNAPSHOT_INVALID"), FT.C.INFO)
+    end
+    for _, n in ipairs(names) do
+        local rec = prov[n]
+        local label = milkLabel
+        if #names > 1 then label = string.format("%s (%s)", milkLabel, fillTypeLabel(n)) end
+        if breedRecordLive(rec) then
+            local litres = math.floor((tonumber(rec.litres) or 0) + 0.5)
+            if litres <= 0 then
+                add(label, FT.l10n("ft_dairy_breed_no_milk", "no milk stored"), FT.C.TEXT_DIM)
+            else
+                add(label, litresText(litres), FT.C.TEXT_NORMAL)
+                for _, e in ipairs(sortedShares(rec.fractions, rec.unknownShare)) do
+                    local l
+                    if e.unknown then
+                        l = tonumber(rec.unknownLitres) or 0
+                    else
+                        l = tonumber(type(rec.knownLitres) == "table" and rec.knownLitres[e.key]) or 0
+                    end
+                    add("  " .. breedLabel(e.key), string.format("%s (%d%%)", litresText(l), pct(e.frac)),
+                        e.unknown and FT.C.TEXT_DIM or FT.C.TEXT_NORMAL)
+                end
+            end
+        else
+            add(label, breedStateLabel(breedRecordReason(rec)), FT.C.INFO)
+        end
+    end
+    return out
+end
+
 FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
     local AC = FT.appColor(FT.APP.DAIRY)
 
@@ -63,6 +264,13 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
               "This tab does not schedule collections, edit contracts,\n" ..
               "or designate feed fields. It surfaces DairyCore's live\n" ..
               "read model only.") },
+        { title = FT.l10n("ft_dairy_breed_help_title", "BREED RECORDS"),
+          body  = FT.l10n("ft_dairy_breed_help_body",
+              "Herd now counts the milking animals in the barn.\n" ..
+              "Milk in tank follows the stored milk by the breeds that\n" ..
+              "produced it. A new herd beside old milk is normal. Unknown\n" ..
+              "milk predates the record or arrived unproven. No breed is\n" ..
+              "rated better here.") },
     }) then return end
 
     local mgr = _dairyMgr()
@@ -72,6 +280,31 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
         if ok and type(result) == "table" then
             rows = result
         end
+    end
+
+    -- DC-27: strict farm gate BEFORE the count, the sort and the cards. Rows carry the
+    -- server-validated breedSurfaceFarmId (never the legacy row.farmId). A row from a
+    -- DairyCore without the breed surface at all (no version) keeps its legacy card and
+    -- says so on the card; a nil farm id or a client still waiting for its mirror shows
+    -- no cards and names the wait.
+    local farmId = playerFarmIdStrict()
+    local waitingServer = false
+    do
+        local kept = {}
+        for _, r in ipairs(rows) do
+            if r.breedSurfaceVersion == nil then
+                kept[#kept + 1] = r
+            elseif farmId ~= nil and type(r.breedSurfaceFarmId) == "number"
+                and r.breedSurfaceFarmId == farmId then
+                kept[#kept + 1] = r
+            elseif r.breedSurfaceFarmId == nil then
+                local h = r.herdBreedComposition
+                if type(h) == "table" and h.available == false and h.reason == "WAITING_FOR_SERVER" then
+                    waitingServer = true
+                end
+            end
+        end
+        rows = kept
     end
 
     table.sort(rows, function(a, b)
@@ -96,11 +329,20 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
     end
 
     if #rows == 0 then
-        self.r:appText(x, startY - FT.py(12), FT.FONT.BODY,
-            FT.l10n("ft_dairy_no_barns", "No dairy barns tracked yet."),
+        local emptyText = FT.l10n("ft_dairy_no_barns", "No dairy barns tracked yet.")
+        local emptyHint = FT.l10n("ft_dairy_no_barns_hint", "Own a dairy barn and DairyCore will list it here.")
+        if farmId == nil then
+            emptyText = breedStateLabel("WAITING_FOR_PLAYER_FARM")
+            emptyHint = FT.l10n("ft_dairy_breed_waiting_farm_hint",
+                "The tablet cannot prove your farm yet. Barn cards stay hidden until it can.")
+        elseif waitingServer then
+            emptyText = breedStateLabel("WAITING_FOR_SERVER")
+            emptyHint = FT.l10n("ft_dairy_breed_waiting_server_hint",
+                "The server has not sent this farm's breed records yet. Barn cards stay hidden until it does.")
+        end
+        self.r:appText(x, startY - FT.py(12), FT.FONT.BODY, emptyText,
             RenderText.ALIGN_LEFT, FT.C.TEXT_DIM)
-        self.r:appText(x, startY - FT.py(30), FT.FONT.SMALL,
-            FT.l10n("ft_dairy_no_barns_hint", "Own a dairy barn and DairyCore will list it here."),
+        self.r:appText(x, startY - FT.py(30), FT.FONT.SMALL, emptyHint,
             RenderText.ALIGN_LEFT, FT.C.MUTED)
         self:drawInfoIcon("_dairyHelp", AC)
         return
@@ -138,6 +380,9 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
         if row.contractId ~= nil then
             lines = lines + 1
         end
+        -- DC-27: the breed rows are counted before the card is sized, like every other line.
+        local breedRows = breedCardRows(row)
+        lines = lines + #breedRows
 
         local headerH = FT.py(22)
         local cardH = headerH + lines * lineH + FT.py(10)
@@ -200,6 +445,11 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
         if row.contractId ~= nil then
             rowY = drawKV(rowY, FT.l10n("ft_dairy_label_contract", "CONTRACT"),
                 tostring(row.contractId), FT.C.TEXT_NORMAL)
+        end
+
+        -- DC-27: the two breed clocks, every breed and fill type listed, unknown named.
+        for _, br in ipairs(breedRows) do
+            rowY = drawKV(rowY, br[1], br[2], br[3])
         end
 
         y = cardBottom - FT.py(8)

--- a/src/utils/DataProvider.lua
+++ b/src/utils/DataProvider.lua
@@ -237,6 +237,20 @@ function FT_DataProvider:getPlayerFarmId()
     return 1
 end
 
+--- DC-27: the strict local-farm read. Positive number only; nil when the player
+--- object or its farm is not available yet. Never falls back to 1.
+function FT_DataProvider:getPlayerFarmIdStrict()
+    if g_localPlayer == nil then return nil end
+    local id = nil
+    if g_localPlayer.getFarmId ~= nil then
+        local ok, v = pcall(function() return g_localPlayer:getFarmId() end)
+        if ok then id = v end
+    end
+    if id == nil then id = g_localPlayer.farmId end
+    if type(id) == "number" and id > 0 then return id end
+    return nil
+end
+
 function FT_DataProvider:getBalance(farmId)
     local v = self:_cached("balance_"..farmId, 1000, function()
         if g_farmManager then

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d conectados" />
         <text name="ft_water_stop_dry" text="Fonte seca" />
         <text name="ft_water_stop_nosource" text="Sem fonte" />
+        <text name="ft_dairy_breed_herd" text="REBANHO ATUAL" />
+        <text name="ft_dairy_breed_milk" text="LEITE NO TANQUE" />
+        <text name="ft_dairy_breed_unknown" text="desconhecido" />
+        <text name="ft_dairy_breed_waiting_server" text="Aguardando o servidor" />
+        <text name="ft_dairy_breed_waiting_farm" text="Aguardando a fazenda do jogador" />
+        <text name="ft_dairy_breed_route_unavailable" text="Rota do tanque indisponível" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tipo de produto não resolvido" />
+        <text name="ft_dairy_breed_storage_missing" text="Sem armazenamento interno" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantâneo inválido" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Rebanho ilegível" />
+        <text name="ft_dairy_breed_update_required" text="Atualização necessária" />
+        <text name="ft_dairy_breed_head" text="%d cabeças" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="sem leite armazenado" />
+        <text name="ft_dairy_breed_source_standard" text="contagem padrão" />
+        <text name="ft_dairy_breed_source_rl" text="contagem Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="O tablet ainda não consegue comprovar sua fazenda. Os cartões de estábulo ficam ocultos até conseguir." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="O servidor ainda não enviou os registros de raças desta fazenda. Os cartões de estábulo ficam ocultos até lá." />
+        <text name="ft_dairy_breed_help_title" text="REGISTROS DE RAÇAS" />
+        <text name="ft_dairy_breed_help_body" text="Rebanho atual conta os animais leiteiros do estábulo.&#10;Leite no tanque segue o leite armazenado pelas raças que&#10;o produziram. Um rebanho novo ao lado de leite antigo é&#10;normal. O leite desconhecido é anterior ao registro ou&#10;chegou por um caminho não comprovado. Nenhuma raça é&#10;avaliada aqui." />
     </texts>
 
 

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="已連接 %d" />
         <text name="ft_water_stop_dry" text="水源乾涸" />
         <text name="ft_water_stop_nosource" text="沒有水源" />
+        <text name="ft_dairy_breed_herd" text="目前畜群" />
+        <text name="ft_dairy_breed_milk" text="槽內牛奶" />
+        <text name="ft_dairy_breed_unknown" text="未知" />
+        <text name="ft_dairy_breed_waiting_server" text="等待伺服器" />
+        <text name="ft_dairy_breed_waiting_farm" text="等待玩家農場" />
+        <text name="ft_dairy_breed_route_unavailable" text="儲槽路線無法使用" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="填充類型無法解析" />
+        <text name="ft_dairy_breed_storage_missing" text="無內部儲存" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="快照無效" />
+        <text name="ft_dairy_breed_herd_unresolved" text="無法讀取畜群" />
+        <text name="ft_dairy_breed_update_required" text="需要更新" />
+        <text name="ft_dairy_breed_head" text="%d頭" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="無儲存牛奶" />
+        <text name="ft_dairy_breed_source_standard" text="標準計數" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock 計數" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="平板尚無法證明你的農場。在證明之前, 牛舍卡片保持隱藏。" />
+        <text name="ft_dairy_breed_waiting_server_hint" text="伺服器尚未傳送這座農場的品種記錄。在此之前, 牛舍卡片保持隱藏。" />
+        <text name="ft_dairy_breed_help_title" text="品種記錄" />
+        <text name="ft_dairy_breed_help_body" text="目前畜群計算牛舍裡的泌乳動物。&#10;槽內牛奶依生產牠的品種追蹤已儲存的牛奶。&#10;舊牛奶旁出現新畜群是正常的。未知牛奶早於記錄,&#10;或經由無法證明的途徑進入。這裡不評價任何品種。" />
     </texts>
 
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d pripojeno" />
         <text name="ft_water_stop_dry" text="Zdroj vyschl" />
         <text name="ft_water_stop_nosource" text="Zadny zdroj" />
+        <text name="ft_dairy_breed_herd" text="STÁDO NYNÍ" />
+        <text name="ft_dairy_breed_milk" text="MLÉKO V NÁDRŽI" />
+        <text name="ft_dairy_breed_unknown" text="neznámé" />
+        <text name="ft_dairy_breed_waiting_server" text="Čekání na server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Čekání na farmu hráče" />
+        <text name="ft_dairy_breed_route_unavailable" text="Trasa nádrže nedostupná" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Typ produktu nerozpoznán" />
+        <text name="ft_dairy_breed_storage_missing" text="Chybí vnitřní sklad" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Snímek neplatný" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Stádo nečitelné" />
+        <text name="ft_dairy_breed_update_required" text="Vyžadována aktualizace" />
+        <text name="ft_dairy_breed_head" text="%d ks" />
+        <text name="ft_dairy_breed_litres" text="%d l" />
+        <text name="ft_dairy_breed_no_milk" text="žádné mléko" />
+        <text name="ft_dairy_breed_source_standard" text="standardní počítání" />
+        <text name="ft_dairy_breed_source_rl" text="počítání Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tablet zatím nemůže prokázat vaši farmu. Karty stájí zůstávají skryté, dokud to nepůjde." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Server ještě neposlal záznamy plemen této farmy. Karty stájí zůstávají do té doby skryté." />
+        <text name="ft_dairy_breed_help_title" text="ZÁZNAMY PLEMEN" />
+        <text name="ft_dairy_breed_help_body" text="Stádo nyní počítá dojná zvířata ve stáji.&#10;Mléko v nádrži sleduje uskladněné mléko podle plemen,&#10;která ho dala. Nové stádo vedle starého mléka je normální.&#10;Neznámé mléko pochází z doby před záznamem nebo přišlo&#10;neprokázanou cestou. Žádné plemeno se zde nehodnotí." />
     </texts>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d tilsluttet" />
         <text name="ft_water_stop_dry" text="Kilden er tor" />
         <text name="ft_water_stop_nosource" text="Ingen kilde" />
+        <text name="ft_dairy_breed_herd" text="BESÆTNING NU" />
+        <text name="ft_dairy_breed_milk" text="MÆLK I TANK" />
+        <text name="ft_dairy_breed_unknown" text="ukendt" />
+        <text name="ft_dairy_breed_waiting_server" text="Venter på server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Venter på spillerens gård" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tankrute ikke tilgængelig" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Fyldtype ikke genkendt" />
+        <text name="ft_dairy_breed_storage_missing" text="Ingen intern lagring" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Øjebliksbillede ugyldigt" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Besætning ulæselig" />
+        <text name="ft_dairy_breed_update_required" text="Opdatering kræves" />
+        <text name="ft_dairy_breed_head" text="%d dyr" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="ingen mælk lagret" />
+        <text name="ft_dairy_breed_source_standard" text="standardtælling" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock-tælling" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tabletten kan endnu ikke bevise din gård. Staldkortene forbliver skjult, indtil den kan." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Serveren har endnu ikke sendt raceregistret for denne gård. Staldkortene forbliver skjult indtil da." />
+        <text name="ft_dairy_breed_help_title" text="RACEREGISTER" />
+        <text name="ft_dairy_breed_help_body" text="Besætning nu tæller malkedyrene i stalden.&#10;Mælk i tank følger den lagrede mælk efter de racer, der&#10;gav den. En ny besætning ved siden af gammel mælk er&#10;normalt. Ukendt mælk er fra før registret eller kom ad en&#10;ubevist vej. Ingen race vurderes her." />
     </texts>
 
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d verbunden" />
         <text name="ft_water_stop_dry" text="Quelle trocken" />
         <text name="ft_water_stop_nosource" text="Keine Quelle" />
+        <text name="ft_dairy_breed_herd" text="HERDE JETZT" />
+        <text name="ft_dairy_breed_milk" text="MILCH IM TANK" />
+        <text name="ft_dairy_breed_unknown" text="unbekannt" />
+        <text name="ft_dairy_breed_waiting_server" text="Warte auf Server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Warte auf Spielerhof" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tankroute nicht verfügbar" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Fülltyp nicht auflösbar" />
+        <text name="ft_dairy_breed_storage_missing" text="Kein interner Speicher" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Momentaufnahme ungültig" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Herde nicht lesbar" />
+        <text name="ft_dairy_breed_update_required" text="Update erforderlich" />
+        <text name="ft_dairy_breed_head" text="%d Tiere" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="keine Milch gelagert" />
+        <text name="ft_dairy_breed_source_standard" text="Standardzählung" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic-Livestock-Zählung" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Das Tablet kann deinen Hof noch nicht belegen. Stallkarten bleiben verborgen, bis es das kann." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Der Server hat die Rassenaufzeichnung dieses Hofs noch nicht gesendet. Stallkarten bleiben bis dahin verborgen." />
+        <text name="ft_dairy_breed_help_title" text="RASSENAUFZEICHNUNG" />
+        <text name="ft_dairy_breed_help_body" text="Herde jetzt zählt die Milchtiere im Stall.&#10;Milch im Tank folgt der gelagerten Milch nach den&#10;Rassen, die sie erzeugt haben. Eine neue Herde neben&#10;alter Milch ist normal. Unbekannte Milch stammt von vor&#10;der Aufzeichnung oder kam auf unbelegtem Weg. Keine&#10;Rasse wird hier bewertet." />
     </texts>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d conectados" />
         <text name="ft_water_stop_dry" text="Fuente seca" />
         <text name="ft_water_stop_nosource" text="Sin fuente" />
+        <text name="ft_dairy_breed_herd" text="HATO ACTUAL" />
+        <text name="ft_dairy_breed_milk" text="LECHE EN TANQUE" />
+        <text name="ft_dairy_breed_unknown" text="desconocido" />
+        <text name="ft_dairy_breed_waiting_server" text="Esperando al servidor" />
+        <text name="ft_dairy_breed_waiting_farm" text="Esperando la granja del jugador" />
+        <text name="ft_dairy_breed_route_unavailable" text="Ruta del tanque no disponible" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tipo de producto sin resolver" />
+        <text name="ft_dairy_breed_storage_missing" text="Sin almacenamiento interno" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantánea no válida" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Hato ilegible" />
+        <text name="ft_dairy_breed_update_required" text="Actualización requerida" />
+        <text name="ft_dairy_breed_head" text="%d cabezas" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="sin leche almacenada" />
+        <text name="ft_dairy_breed_source_standard" text="conteo estándar" />
+        <text name="ft_dairy_breed_source_rl" text="conteo Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="La tablet aún no puede comprobar tu granja. Las tarjetas de establo quedan ocultas hasta que pueda." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="El servidor aún no ha enviado los registros de razas de esta granja. Las tarjetas de establo quedan ocultas hasta entonces." />
+        <text name="ft_dairy_breed_help_title" text="REGISTROS DE RAZAS" />
+        <text name="ft_dairy_breed_help_body" text="Hato actual cuenta los animales lecheros del establo.&#10;Leche en tanque sigue la leche almacenada por las razas&#10;que la produjeron. Un hato nuevo junto a leche vieja es&#10;normal. La leche desconocida es anterior al registro o&#10;llegó por una vía no comprobada. Ninguna raza se califica aquí." />
     </texts>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -2587,6 +2587,26 @@
         <text name="ft_water_connected" text="%d connected" />
         <text name="ft_water_stop_dry" text="Dry source" />
         <text name="ft_water_stop_nosource" text="No source" />
+        <text name="ft_dairy_breed_herd" text="HERD NOW" />
+        <text name="ft_dairy_breed_milk" text="MILK IN TANK" />
+        <text name="ft_dairy_breed_unknown" text="unknown" />
+        <text name="ft_dairy_breed_waiting_server" text="Waiting for server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Waiting for player farm" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tank route unavailable" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Fill type unresolved" />
+        <text name="ft_dairy_breed_storage_missing" text="No internal storage" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Snapshot invalid" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Herd unreadable" />
+        <text name="ft_dairy_breed_update_required" text="Update required" />
+        <text name="ft_dairy_breed_head" text="%d head" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="no milk stored" />
+        <text name="ft_dairy_breed_source_standard" text="standard count" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock count" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="The tablet cannot prove your farm yet. Barn cards stay hidden until it can." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="The server has not sent this farm's breed records yet. Barn cards stay hidden until it does." />
+        <text name="ft_dairy_breed_help_title" text="BREED RECORDS" />
+        <text name="ft_dairy_breed_help_body" text="Herd now counts the milking animals in the barn.&#10;Milk in tank follows the stored milk by the breeds that&#10;produced it. A new herd beside old milk is normal. Unknown&#10;milk predates the record or arrived unproven. No breed is&#10;rated better here." />
     </texts>
 
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d conectados" />
         <text name="ft_water_stop_dry" text="Fuente seca" />
         <text name="ft_water_stop_nosource" text="Sin fuente" />
+        <text name="ft_dairy_breed_herd" text="REBAÑO ACTUAL" />
+        <text name="ft_dairy_breed_milk" text="LECHE EN TANQUE" />
+        <text name="ft_dairy_breed_unknown" text="desconocido" />
+        <text name="ft_dairy_breed_waiting_server" text="Esperando al servidor" />
+        <text name="ft_dairy_breed_waiting_farm" text="Esperando la granja del jugador" />
+        <text name="ft_dairy_breed_route_unavailable" text="Ruta del tanque no disponible" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tipo de producto sin resolver" />
+        <text name="ft_dairy_breed_storage_missing" text="Sin almacenamiento interno" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantánea no válida" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Rebaño ilegible" />
+        <text name="ft_dairy_breed_update_required" text="Actualización requerida" />
+        <text name="ft_dairy_breed_head" text="%d cabezas" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="sin leche almacenada" />
+        <text name="ft_dairy_breed_source_standard" text="recuento estándar" />
+        <text name="ft_dairy_breed_source_rl" text="recuento Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="La tableta aún no puede probar tu granja. Las fichas de establo quedan ocultas hasta que pueda." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="El servidor aún no ha enviado los registros de razas de esta granja. Las fichas de establo quedan ocultas hasta entonces." />
+        <text name="ft_dairy_breed_help_title" text="REGISTROS DE RAZAS" />
+        <text name="ft_dairy_breed_help_body" text="Rebaño actual cuenta los animales lecheros del establo.&#10;Leche en tanque sigue la leche almacenada por las razas&#10;que la produjeron. Un rebaño nuevo junto a leche antigua&#10;es normal. La leche desconocida es anterior al registro o&#10;llegó por una vía no probada. Ninguna raza se valora aquí." />
     </texts>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="已连接 %d" />
         <text name="ft_water_stop_dry" text="水源干涸" />
         <text name="ft_water_stop_nosource" text="没有水源" />
+        <text name="ft_dairy_breed_herd" text="TROUPEAU ACTUEL" />
+        <text name="ft_dairy_breed_milk" text="LAIT AU RÉSERVOIR" />
+        <text name="ft_dairy_breed_unknown" text="inconnu" />
+        <text name="ft_dairy_breed_waiting_server" text="En attente du serveur" />
+        <text name="ft_dairy_breed_waiting_farm" text="En attente de la ferme du joueur" />
+        <text name="ft_dairy_breed_route_unavailable" text="Réservoir partagé indisponible" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Type de produit non résolu" />
+        <text name="ft_dairy_breed_storage_missing" text="Aucun stockage interne" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantané invalide" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Troupeau illisible" />
+        <text name="ft_dairy_breed_update_required" text="Mise à jour requise" />
+        <text name="ft_dairy_breed_head" text="%d têtes" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="aucun lait stocké" />
+        <text name="ft_dairy_breed_source_standard" text="comptage standard" />
+        <text name="ft_dairy_breed_source_rl" text="comptage Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="La tablette ne peut pas encore prouver votre ferme. Les fiches d'étable restent masquées jusque-là." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Le serveur n'a pas encore envoyé les registres de races de cette ferme. Les fiches d'étable restent masquées jusque-là." />
+        <text name="ft_dairy_breed_help_title" text="REGISTRES DE RACES" />
+        <text name="ft_dairy_breed_help_body" text="Troupeau actuel compte les animaux laitiers de l'étable.&#10;Lait au réservoir suit le lait stocké selon les races qui l'ont&#10;produit. Un nouveau troupeau à côté d'un lait ancien est&#10;normal. Le lait inconnu précède le registre ou est arrivé&#10;par un chemin non prouvé. Aucune race n'est notée ici." />
     </texts>
 
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d liitetty" />
         <text name="ft_water_stop_dry" text="Lahde kuiva" />
         <text name="ft_water_stop_nosource" text="Ei lahdetta" />
+        <text name="ft_dairy_breed_herd" text="KARJA NYT" />
+        <text name="ft_dairy_breed_milk" text="MAITO SÄILIÖSSÄ" />
+        <text name="ft_dairy_breed_unknown" text="tuntematon" />
+        <text name="ft_dairy_breed_waiting_server" text="Odotetaan palvelinta" />
+        <text name="ft_dairy_breed_waiting_farm" text="Odotetaan pelaajan tilaa" />
+        <text name="ft_dairy_breed_route_unavailable" text="Säiliöreitti ei saatavilla" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Täyttötyyppiä ei tunnistettu" />
+        <text name="ft_dairy_breed_storage_missing" text="Ei sisäistä varastoa" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Tilannekuva virheellinen" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Karjaa ei voi lukea" />
+        <text name="ft_dairy_breed_update_required" text="Päivitys vaaditaan" />
+        <text name="ft_dairy_breed_head" text="%d päätä" />
+        <text name="ft_dairy_breed_litres" text="%d l" />
+        <text name="ft_dairy_breed_no_milk" text="ei varastoitua maitoa" />
+        <text name="ft_dairy_breed_source_standard" text="vakiolaskenta" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock -laskenta" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tabletti ei vielä voi todentaa tilaasi. Navettakortit pysyvät piilossa siihen asti." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Palvelin ei ole vielä lähettänyt tämän tilan rotukirjausta. Navettakortit pysyvät piilossa siihen asti." />
+        <text name="ft_dairy_breed_help_title" text="ROTUKIRJAUS" />
+        <text name="ft_dairy_breed_help_body" text="Karja nyt laskee navetan lypsyeläimet.&#10;Maito säiliössä seuraa varastoitua maitoa sen tuottaneiden&#10;rotujen mukaan. Uusi karja vanhan maidon rinnalla on&#10;normaalia. Tuntematon maito on kirjausta vanhempaa tai&#10;tuli todistamatonta reittiä. Rotuja ei arvoteta tässä." />
     </texts>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d connectes" />
         <text name="ft_water_stop_dry" text="Source a sec" />
         <text name="ft_water_stop_nosource" text="Aucune source" />
+        <text name="ft_dairy_breed_herd" text="TROUPEAU ACTUEL" />
+        <text name="ft_dairy_breed_milk" text="LAIT EN CUVE" />
+        <text name="ft_dairy_breed_unknown" text="inconnu" />
+        <text name="ft_dairy_breed_waiting_server" text="En attente du serveur" />
+        <text name="ft_dairy_breed_waiting_farm" text="En attente de la ferme du joueur" />
+        <text name="ft_dairy_breed_route_unavailable" text="Cuve partagée indisponible" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Type de produit non résolu" />
+        <text name="ft_dairy_breed_storage_missing" text="Aucun stockage interne" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantané invalide" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Troupeau illisible" />
+        <text name="ft_dairy_breed_update_required" text="Mise à jour requise" />
+        <text name="ft_dairy_breed_head" text="%d têtes" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="aucun lait stocké" />
+        <text name="ft_dairy_breed_source_standard" text="comptage standard" />
+        <text name="ft_dairy_breed_source_rl" text="comptage Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="La tablette ne peut pas encore prouver votre ferme. Les fiches d'étable restent masquées jusque-là." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Le serveur n'a pas encore envoyé les registres de races de cette ferme. Les fiches d'étable restent masquées jusque-là." />
+        <text name="ft_dairy_breed_help_title" text="REGISTRES DE RACES" />
+        <text name="ft_dairy_breed_help_body" text="Troupeau actuel compte les animaux laitiers de l'étable.&#10;Lait en cuve suit le lait stocké selon les races qui l'ont&#10;produit. Un nouveau troupeau à côté d'un lait ancien est&#10;normal. Le lait inconnu précède le registre ou est arrivé&#10;par un chemin non prouvé. Aucune race n'est notée ici." />
     </texts>
 
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d csatlakoztatva" />
         <text name="ft_water_stop_dry" text="Szaraz forras" />
         <text name="ft_water_stop_nosource" text="Nincs forras" />
+        <text name="ft_dairy_breed_herd" text="ÁLLOMÁNY MOST" />
+        <text name="ft_dairy_breed_milk" text="TEJ A TARTÁLYBAN" />
+        <text name="ft_dairy_breed_unknown" text="ismeretlen" />
+        <text name="ft_dairy_breed_waiting_server" text="Várakozás a szerverre" />
+        <text name="ft_dairy_breed_waiting_farm" text="Várakozás a játékos farmjára" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tartályútvonal nem elérhető" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Ismeretlen terméktípus" />
+        <text name="ft_dairy_breed_storage_missing" text="Nincs belső tároló" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Pillanatkép érvénytelen" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Állomány nem olvasható" />
+        <text name="ft_dairy_breed_update_required" text="Frissítés szükséges" />
+        <text name="ft_dairy_breed_head" text="%d egyed" />
+        <text name="ft_dairy_breed_litres" text="%d l" />
+        <text name="ft_dairy_breed_no_milk" text="nincs tárolt tej" />
+        <text name="ft_dairy_breed_source_standard" text="normál számlálás" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock számlálás" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="A tablet még nem tudja igazolni a farmodat. Az istállókártyák addig rejtve maradnak." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="A szerver még nem küldte el ennek a farmnak a fajta-nyilvántartását. Az istállókártyák addig rejtve maradnak." />
+        <text name="ft_dairy_breed_help_title" text="FAJTA-NYILVÁNTARTÁS" />
+        <text name="ft_dairy_breed_help_body" text="Állomány most az istállóban álló tejelő állatokat számolja.&#10;Tej a tartályban a tárolt tejet követi az azt adó fajták&#10;szerint. Új állomány régi tej mellett normális. Az&#10;ismeretlen tej a nyilvántartás előtti, vagy nem igazolt&#10;úton érkezett. Egyetlen fajtát sem értékelünk itt." />
     </texts>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d terhubung" />
         <text name="ft_water_stop_dry" text="Sumber kering" />
         <text name="ft_water_stop_nosource" text="Tidak ada sumber" />
+        <text name="ft_dairy_breed_herd" text="KAWANAN SAAT INI" />
+        <text name="ft_dairy_breed_milk" text="SUSU DI TANGKI" />
+        <text name="ft_dairy_breed_unknown" text="tidak diketahui" />
+        <text name="ft_dairy_breed_waiting_server" text="Menunggu server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Menunggu peternakan pemain" />
+        <text name="ft_dairy_breed_route_unavailable" text="Rute tangki tidak tersedia" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Jenis isi tidak dikenali" />
+        <text name="ft_dairy_breed_storage_missing" text="Tidak ada penyimpanan internal" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Snapshot tidak valid" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Kawanan tidak terbaca" />
+        <text name="ft_dairy_breed_update_required" text="Perlu pembaruan" />
+        <text name="ft_dairy_breed_head" text="%d ekor" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="tidak ada susu tersimpan" />
+        <text name="ft_dairy_breed_source_standard" text="hitungan standar" />
+        <text name="ft_dairy_breed_source_rl" text="hitungan Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tablet belum bisa membuktikan peternakan Anda. Kartu kandang tetap tersembunyi sampai bisa." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Server belum mengirim catatan ras peternakan ini. Kartu kandang tetap tersembunyi sampai terkirim." />
+        <text name="ft_dairy_breed_help_title" text="CATATAN RAS" />
+        <text name="ft_dairy_breed_help_body" text="Kawanan saat ini menghitung hewan perah di kandang.&#10;Susu di tangki mengikuti susu yang tersimpan menurut ras&#10;yang menghasilkannya. Kawanan baru di samping susu lama&#10;itu normal. Susu tidak diketahui berasal dari sebelum&#10;pencatatan atau masuk lewat jalur yang tidak terbukti.&#10;Tidak ada ras yang dinilai di sini." />
     </texts>
 
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d collegati" />
         <text name="ft_water_stop_dry" text="Fonte secca" />
         <text name="ft_water_stop_nosource" text="Nessuna fonte" />
+        <text name="ft_dairy_breed_herd" text="MANDRIA ATTUALE" />
+        <text name="ft_dairy_breed_milk" text="LATTE IN CISTERNA" />
+        <text name="ft_dairy_breed_unknown" text="sconosciuto" />
+        <text name="ft_dairy_breed_waiting_server" text="In attesa del server" />
+        <text name="ft_dairy_breed_waiting_farm" text="In attesa della fattoria del giocatore" />
+        <text name="ft_dairy_breed_route_unavailable" text="Cisterna condivisa non disponibile" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tipo di prodotto non risolto" />
+        <text name="ft_dairy_breed_storage_missing" text="Nessun deposito interno" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Istantanea non valida" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Mandria illeggibile" />
+        <text name="ft_dairy_breed_update_required" text="Aggiornamento richiesto" />
+        <text name="ft_dairy_breed_head" text="%d capi" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="nessun latte stoccato" />
+        <text name="ft_dairy_breed_source_standard" text="conteggio standard" />
+        <text name="ft_dairy_breed_source_rl" text="conteggio Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Il tablet non può ancora provare la tua fattoria. Le schede stalla restano nascoste finché non può." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Il server non ha ancora inviato i registri razze di questa fattoria. Le schede stalla restano nascoste fino ad allora." />
+        <text name="ft_dairy_breed_help_title" text="REGISTRI RAZZE" />
+        <text name="ft_dairy_breed_help_body" text="Mandria attuale conta gli animali da latte nella stalla.&#10;Latte in cisterna segue il latte stoccato per razza che&#10;lo ha prodotto. Una mandria nuova accanto a latte vecchio&#10;è normale. Il latte sconosciuto precede il registro o è&#10;arrivato per una via non provata. Nessuna razza viene&#10;valutata qui." />
     </texts>
 
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d 接続" />
         <text name="ft_water_stop_dry" text="水源が枯渇" />
         <text name="ft_water_stop_nosource" text="水源なし" />
+        <text name="ft_dairy_breed_herd" text="現在の群れ" />
+        <text name="ft_dairy_breed_milk" text="タンク内の牛乳" />
+        <text name="ft_dairy_breed_unknown" text="不明" />
+        <text name="ft_dairy_breed_waiting_server" text="サーバー待機中" />
+        <text name="ft_dairy_breed_waiting_farm" text="プレイヤー農場待機中" />
+        <text name="ft_dairy_breed_route_unavailable" text="タンク経路は利用不可" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="充填タイプ未解決" />
+        <text name="ft_dairy_breed_storage_missing" text="内部貯蔵なし" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="スナップショット無効" />
+        <text name="ft_dairy_breed_herd_unresolved" text="群れを読み取れません" />
+        <text name="ft_dairy_breed_update_required" text="更新が必要" />
+        <text name="ft_dairy_breed_head" text="%d頭" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="貯蔵牛乳なし" />
+        <text name="ft_dairy_breed_source_standard" text="標準集計" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock 集計" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="タブレットはまだあなたの農場を証明できません。証明できるまで畜舎カードは非表示です。" />
+        <text name="ft_dairy_breed_waiting_server_hint" text="サーバーはこの農場の品種記録をまだ送信していません。それまで畜舎カードは非表示です。" />
+        <text name="ft_dairy_breed_help_title" text="品種記録" />
+        <text name="ft_dairy_breed_help_body" text="現在の群れは畜舎の搾乳動物を数えます。&#10;タンク内の牛乳は貯蔵された牛乳を生産した品種ごとに&#10;追跡します。古い牛乳の横に新しい群れがいるのは正常です。&#10;不明な牛乳は記録以前のものか、証明できない経路で&#10;入ったものです。ここで品種を評価することはありません。" />
     </texts>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d개 연결됨" />
         <text name="ft_water_stop_dry" text="수원 고갈" />
         <text name="ft_water_stop_nosource" text="수원 없음" />
+        <text name="ft_dairy_breed_herd" text="현재 무리" />
+        <text name="ft_dairy_breed_milk" text="탱크의 우유" />
+        <text name="ft_dairy_breed_unknown" text="알 수 없음" />
+        <text name="ft_dairy_breed_waiting_server" text="서버 대기 중" />
+        <text name="ft_dairy_breed_waiting_farm" text="플레이어 농장 대기 중" />
+        <text name="ft_dairy_breed_route_unavailable" text="탱크 경로 사용 불가" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="채움 유형 미확인" />
+        <text name="ft_dairy_breed_storage_missing" text="내부 저장소 없음" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="스냅샷 무효" />
+        <text name="ft_dairy_breed_herd_unresolved" text="무리를 읽을 수 없음" />
+        <text name="ft_dairy_breed_update_required" text="업데이트 필요" />
+        <text name="ft_dairy_breed_head" text="%d마리" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="저장된 우유 없음" />
+        <text name="ft_dairy_breed_source_standard" text="표준 집계" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock 집계" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="태블릿이 아직 농장을 확인할 수 없습니다. 확인될 때까지 축사 카드는 숨겨집니다." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="서버가 아직 이 농장의 품종 기록을 보내지 않았습니다. 그때까지 축사 카드는 숨겨집니다." />
+        <text name="ft_dairy_breed_help_title" text="품종 기록" />
+        <text name="ft_dairy_breed_help_body" text="현재 무리는 축사의 착유 동물을 셉니다.&#10;탱크의 우유는 저장된 우유를 생산한 품종별로&#10;따라갑니다. 오래된 우유 옆의 새 무리는 정상입니다.&#10;알 수 없는 우유는 기록 이전 것이거나 증명되지 않은&#10;경로로 들어온 것입니다. 여기서 품종을 평가하지 않습니다." />
     </texts>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d verbonden" />
         <text name="ft_water_stop_dry" text="Bron droog" />
         <text name="ft_water_stop_nosource" text="Geen bron" />
+        <text name="ft_dairy_breed_herd" text="KUDDE NU" />
+        <text name="ft_dairy_breed_milk" text="MELK IN TANK" />
+        <text name="ft_dairy_breed_unknown" text="onbekend" />
+        <text name="ft_dairy_breed_waiting_server" text="Wachten op server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Wachten op spelersboerderij" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tankroute niet beschikbaar" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Vultype niet herkend" />
+        <text name="ft_dairy_breed_storage_missing" text="Geen interne opslag" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Momentopname ongeldig" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Kudde niet leesbaar" />
+        <text name="ft_dairy_breed_update_required" text="Update vereist" />
+        <text name="ft_dairy_breed_head" text="%d dieren" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="geen melk opgeslagen" />
+        <text name="ft_dairy_breed_source_standard" text="standaardtelling" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock-telling" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="De tablet kan je boerderij nog niet bewijzen. Stalkaarten blijven verborgen tot dat lukt." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="De server heeft de rasregistratie van deze boerderij nog niet gestuurd. Stalkaarten blijven tot dan verborgen." />
+        <text name="ft_dairy_breed_help_title" text="RASREGISTRATIE" />
+        <text name="ft_dairy_breed_help_body" text="Kudde nu telt de melkdieren in de stal.&#10;Melk in tank volgt de opgeslagen melk per ras dat haar&#10;produceerde. Een nieuwe kudde naast oude melk is normaal.&#10;Onbekende melk dateert van voor de registratie of kwam&#10;langs een onbewezen weg. Geen ras wordt hier beoordeeld." />
     </texts>
 
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d tilkoblet" />
         <text name="ft_water_stop_dry" text="Kilden er torr" />
         <text name="ft_water_stop_nosource" text="Ingen kilde" />
+        <text name="ft_dairy_breed_herd" text="BESETNING NÅ" />
+        <text name="ft_dairy_breed_milk" text="MELK I TANK" />
+        <text name="ft_dairy_breed_unknown" text="ukjent" />
+        <text name="ft_dairy_breed_waiting_server" text="Venter på server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Venter på spillerens gård" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tankrute utilgjengelig" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Fylltype ikke gjenkjent" />
+        <text name="ft_dairy_breed_storage_missing" text="Ingen intern lagring" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Øyeblikksbilde ugyldig" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Besetning uleselig" />
+        <text name="ft_dairy_breed_update_required" text="Oppdatering kreves" />
+        <text name="ft_dairy_breed_head" text="%d dyr" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="ingen melk lagret" />
+        <text name="ft_dairy_breed_source_standard" text="standardtelling" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock-telling" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Nettbrettet kan ikke bevise gården din ennå. Fjøskortene forblir skjult til det kan." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Serveren har ikke sendt raseregisteret for denne gården ennå. Fjøskortene forblir skjult til da." />
+        <text name="ft_dairy_breed_help_title" text="RASEREGISTER" />
+        <text name="ft_dairy_breed_help_body" text="Besetning nå teller melkedyrene i fjøset.&#10;Melk i tank følger den lagrede melken etter rasene som&#10;ga den. En ny besetning ved siden av gammel melk er&#10;normalt. Ukjent melk er fra før registeret eller kom en&#10;ubevist vei. Ingen rase vurderes her." />
     </texts>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d podlaczonych" />
         <text name="ft_water_stop_dry" text="Zrodlo suche" />
         <text name="ft_water_stop_nosource" text="Brak zrodla" />
+        <text name="ft_dairy_breed_herd" text="STADO TERAZ" />
+        <text name="ft_dairy_breed_milk" text="MLEKO W ZBIORNIKU" />
+        <text name="ft_dairy_breed_unknown" text="nieznane" />
+        <text name="ft_dairy_breed_waiting_server" text="Oczekiwanie na serwer" />
+        <text name="ft_dairy_breed_waiting_farm" text="Oczekiwanie na farmę gracza" />
+        <text name="ft_dairy_breed_route_unavailable" text="Trasa zbiornika niedostępna" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Nierozpoznany typ produktu" />
+        <text name="ft_dairy_breed_storage_missing" text="Brak wewnętrznego magazynu" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Migawka nieprawidłowa" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Stado nieczytelne" />
+        <text name="ft_dairy_breed_update_required" text="Wymagana aktualizacja" />
+        <text name="ft_dairy_breed_head" text="%d szt." />
+        <text name="ft_dairy_breed_litres" text="%d l" />
+        <text name="ft_dairy_breed_no_milk" text="brak mleka w magazynie" />
+        <text name="ft_dairy_breed_source_standard" text="liczenie standardowe" />
+        <text name="ft_dairy_breed_source_rl" text="liczenie Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tablet nie może jeszcze potwierdzić twojej farmy. Karty obór pozostają ukryte, dopóki nie będzie mógł." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Serwer nie przesłał jeszcze rejestru ras tej farmy. Karty obór pozostają do tego czasu ukryte." />
+        <text name="ft_dairy_breed_help_title" text="REJESTR RAS" />
+        <text name="ft_dairy_breed_help_body" text="Stado teraz liczy zwierzęta mleczne w oborze.&#10;Mleko w zbiorniku śledzi zmagazynowane mleko według ras,&#10;które je dały. Nowe stado obok starego mleka to normalne.&#10;Nieznane mleko pochodzi sprzed rejestru lub trafiło tu&#10;niepotwierdzoną drogą. Żadna rasa nie jest tu oceniana." />
     </texts>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d ligados" />
         <text name="ft_water_stop_dry" text="Fonte seca" />
         <text name="ft_water_stop_nosource" text="Sem fonte" />
+        <text name="ft_dairy_breed_herd" text="REBANHO ATUAL" />
+        <text name="ft_dairy_breed_milk" text="LEITE NO TANQUE" />
+        <text name="ft_dairy_breed_unknown" text="desconhecido" />
+        <text name="ft_dairy_breed_waiting_server" text="A aguardar o servidor" />
+        <text name="ft_dairy_breed_waiting_farm" text="A aguardar a quinta do jogador" />
+        <text name="ft_dairy_breed_route_unavailable" text="Rota do tanque indisponível" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tipo de produto não resolvido" />
+        <text name="ft_dairy_breed_storage_missing" text="Sem armazenamento interno" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantâneo inválido" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Rebanho ilegível" />
+        <text name="ft_dairy_breed_update_required" text="Atualização necessária" />
+        <text name="ft_dairy_breed_head" text="%d cabeças" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="sem leite armazenado" />
+        <text name="ft_dairy_breed_source_standard" text="contagem padrão" />
+        <text name="ft_dairy_breed_source_rl" text="contagem Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="O tablet ainda não consegue provar a sua quinta. As fichas de estábulo ficam ocultas até conseguir." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="O servidor ainda não enviou os registos de raças desta quinta. As fichas de estábulo ficam ocultas até lá." />
+        <text name="ft_dairy_breed_help_title" text="REGISTOS DE RAÇAS" />
+        <text name="ft_dairy_breed_help_body" text="Rebanho atual conta os animais leiteiros do estábulo.&#10;Leite no tanque segue o leite armazenado pelas raças que&#10;o produziram. Um rebanho novo ao lado de leite antigo é&#10;normal. O leite desconhecido é anterior ao registo ou&#10;chegou por um caminho não provado. Nenhuma raça é&#10;avaliada aqui." />
     </texts>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d conectate" />
         <text name="ft_water_stop_dry" text="Sursa uscata" />
         <text name="ft_water_stop_nosource" text="Fara sursa" />
+        <text name="ft_dairy_breed_herd" text="TURMA ACUM" />
+        <text name="ft_dairy_breed_milk" text="LAPTE ÎN TANC" />
+        <text name="ft_dairy_breed_unknown" text="necunoscut" />
+        <text name="ft_dairy_breed_waiting_server" text="Se așteaptă serverul" />
+        <text name="ft_dairy_breed_waiting_farm" text="Se așteaptă ferma jucătorului" />
+        <text name="ft_dairy_breed_route_unavailable" text="Ruta tancului indisponibilă" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Tip de produs nerezolvat" />
+        <text name="ft_dairy_breed_storage_missing" text="Fără depozit intern" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Instantaneu invalid" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Turmă ilizibilă" />
+        <text name="ft_dairy_breed_update_required" text="Actualizare necesară" />
+        <text name="ft_dairy_breed_head" text="%d capete" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="fără lapte depozitat" />
+        <text name="ft_dairy_breed_source_standard" text="numărare standard" />
+        <text name="ft_dairy_breed_source_rl" text="numărare Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tableta nu poate încă dovedi ferma ta. Fișele grajdurilor rămân ascunse până poate." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Serverul nu a trimis încă registrele de rase ale acestei ferme. Fișele grajdurilor rămân ascunse până atunci." />
+        <text name="ft_dairy_breed_help_title" text="REGISTRE DE RASE" />
+        <text name="ft_dairy_breed_help_body" text="Turma acum numără animalele de lapte din grajd.&#10;Lapte în tanc urmărește laptele depozitat după rasele&#10;care l-au produs. O turmă nouă lângă lapte vechi este&#10;normal. Laptele necunoscut precede registrul sau a ajuns&#10;pe o cale nedovedită. Nicio rasă nu este evaluată aici." />
     </texts>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -2627,6 +2627,26 @@
         <text name="ft_water_connected" text="%d подключено" />
         <text name="ft_water_stop_dry" text="Источник сухой" />
         <text name="ft_water_stop_nosource" text="Нет источника" />
+        <text name="ft_dairy_breed_herd" text="СТАДО СЕЙЧАС" />
+        <text name="ft_dairy_breed_milk" text="МОЛОКО В ТАНКЕ" />
+        <text name="ft_dairy_breed_unknown" text="неизвестно" />
+        <text name="ft_dairy_breed_waiting_server" text="Ожидание сервера" />
+        <text name="ft_dairy_breed_waiting_farm" text="Ожидание фермы игрока" />
+        <text name="ft_dairy_breed_route_unavailable" text="Маршрут танка недоступен" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Тип продукта не распознан" />
+        <text name="ft_dairy_breed_storage_missing" text="Нет внутреннего хранилища" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Снимок недействителен" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Стадо не читается" />
+        <text name="ft_dairy_breed_update_required" text="Требуется обновление" />
+        <text name="ft_dairy_breed_head" text="%d гол." />
+        <text name="ft_dairy_breed_litres" text="%d л" />
+        <text name="ft_dairy_breed_no_milk" text="молока нет" />
+        <text name="ft_dairy_breed_source_standard" text="стандартный подсчёт" />
+        <text name="ft_dairy_breed_source_rl" text="подсчёт Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Планшет пока не может подтвердить вашу ферму. Карточки хлевов скрыты, пока не сможет." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Сервер ещё не прислал записи пород этой фермы. Карточки хлевов скрыты до тех пор." />
+        <text name="ft_dairy_breed_help_title" text="ЗАПИСИ ПОРОД" />
+        <text name="ft_dairy_breed_help_body" text="Стадо сейчас считает дойных животных в хлеву.&#10;Молоко в танке следует за хранящимся молоком по породам,&#10;которые его дали. Новое стадо рядом со старым молоком -&#10;это нормально. Неизвестное молоко было до записи или&#10;пришло непроверенным путём. Породы здесь не оцениваются." />
     </texts>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d anslutna" />
         <text name="ft_water_stop_dry" text="Kallan ar torr" />
         <text name="ft_water_stop_nosource" text="Ingen kalla" />
+        <text name="ft_dairy_breed_herd" text="BESÄTTNING NU" />
+        <text name="ft_dairy_breed_milk" text="MJÖLK I TANK" />
+        <text name="ft_dairy_breed_unknown" text="okänd" />
+        <text name="ft_dairy_breed_waiting_server" text="Väntar på server" />
+        <text name="ft_dairy_breed_waiting_farm" text="Väntar på spelarens gård" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tankrutt ej tillgänglig" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Fyllningstyp okänd" />
+        <text name="ft_dairy_breed_storage_missing" text="Ingen intern lagring" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Ögonblicksbild ogiltig" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Besättning oläslig" />
+        <text name="ft_dairy_breed_update_required" text="Uppdatering krävs" />
+        <text name="ft_dairy_breed_head" text="%d djur" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="ingen mjölk lagrad" />
+        <text name="ft_dairy_breed_source_standard" text="standardräkning" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock-räkning" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Surfplattan kan inte bevisa din gård ännu. Ladugårdskorten förblir dolda tills den kan." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Servern har inte skickat rasregistret för den här gården ännu. Ladugårdskorten förblir dolda tills dess." />
+        <text name="ft_dairy_breed_help_title" text="RASREGISTER" />
+        <text name="ft_dairy_breed_help_body" text="Besättning nu räknar mjölkdjuren i ladugården.&#10;Mjölk i tank följer den lagrade mjölken efter raserna som&#10;gav den. En ny besättning bredvid gammal mjölk är normalt.&#10;Okänd mjölk är från före registret eller kom en obevisad&#10;väg. Ingen ras bedöms här." />
     </texts>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -2586,6 +2586,26 @@
         <text name="ft_water_connected" text="%d bagli" />
         <text name="ft_water_stop_dry" text="Kaynak kuru" />
         <text name="ft_water_stop_nosource" text="Kaynak yok" />
+        <text name="ft_dairy_breed_herd" text="ŞU ANKI SÜRÜ" />
+        <text name="ft_dairy_breed_milk" text="TANKTAKI SÜT" />
+        <text name="ft_dairy_breed_unknown" text="bilinmiyor" />
+        <text name="ft_dairy_breed_waiting_server" text="Sunucu bekleniyor" />
+        <text name="ft_dairy_breed_waiting_farm" text="Oyuncu çiftliği bekleniyor" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tank rotası kullanılamıyor" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Ürün türü çözülemedi" />
+        <text name="ft_dairy_breed_storage_missing" text="İç depo yok" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Anlık görüntü geçersiz" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Sürü okunamıyor" />
+        <text name="ft_dairy_breed_update_required" text="Güncelleme gerekli" />
+        <text name="ft_dairy_breed_head" text="%d baş" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="depolanmış süt yok" />
+        <text name="ft_dairy_breed_source_standard" text="standart sayım" />
+        <text name="ft_dairy_breed_source_rl" text="Realistic Livestock sayımı" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Tablet çiftliğini henüz kanıtlayamıyor. Ahır kartları kanıtlayana kadar gizli kalır." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Sunucu bu çiftliğin ırk kayıtlarını henüz göndermedi. Ahır kartları o zamana kadar gizli kalır." />
+        <text name="ft_dairy_breed_help_title" text="IRK KAYITLARI" />
+        <text name="ft_dairy_breed_help_body" text="Şu anki sürü ahırdaki sağmal hayvanları sayar.&#10;Tanktaki süt, depolanan sütü onu üreten ırklara göre&#10;izler. Eski sütün yanında yeni bir sürü normaldir.&#10;Bilinmeyen süt kayıttan öncedir ya da kanıtlanmamış bir&#10;yoldan gelmiştir. Burada hiçbir ırk derecelendirilmez." />
     </texts>
 
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d підключено" />
         <text name="ft_water_stop_dry" text="Джерело сухе" />
         <text name="ft_water_stop_nosource" text="Немає джерела" />
+        <text name="ft_dairy_breed_herd" text="СТАДО ЗАРАЗ" />
+        <text name="ft_dairy_breed_milk" text="МОЛОКО В ТАНКУ" />
+        <text name="ft_dairy_breed_unknown" text="невідомо" />
+        <text name="ft_dairy_breed_waiting_server" text="Очікування сервера" />
+        <text name="ft_dairy_breed_waiting_farm" text="Очікування ферми гравця" />
+        <text name="ft_dairy_breed_route_unavailable" text="Маршрут танка недоступний" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Тип продукту не розпізнано" />
+        <text name="ft_dairy_breed_storage_missing" text="Немає внутрішнього сховища" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Знімок недійсний" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Стадо не читається" />
+        <text name="ft_dairy_breed_update_required" text="Потрібне оновлення" />
+        <text name="ft_dairy_breed_head" text="%d гол." />
+        <text name="ft_dairy_breed_litres" text="%d л" />
+        <text name="ft_dairy_breed_no_milk" text="молока немає" />
+        <text name="ft_dairy_breed_source_standard" text="стандартний підрахунок" />
+        <text name="ft_dairy_breed_source_rl" text="підрахунок Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Планшет поки не може підтвердити вашу ферму. Картки хлівів приховані, доки не зможе." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Сервер ще не надіслав записи порід цієї ферми. Картки хлівів приховані до того часу." />
+        <text name="ft_dairy_breed_help_title" text="ЗАПИСИ ПОРІД" />
+        <text name="ft_dairy_breed_help_body" text="Стадо зараз рахує дійних тварин у хліві.&#10;Молоко в танку слідує за збереженим молоком за породами,&#10;які його дали. Нове стадо поруч зі старим молоком - це&#10;нормально. Невідоме молоко було до запису або надійшло&#10;неперевіреним шляхом. Породи тут не оцінюються." />
     </texts>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -2585,6 +2585,26 @@
         <text name="ft_water_connected" text="%d ket noi" />
         <text name="ft_water_stop_dry" text="Nguon can" />
         <text name="ft_water_stop_nosource" text="Khong co nguon" />
+        <text name="ft_dairy_breed_herd" text="ĐÀN HIỆN TẠI" />
+        <text name="ft_dairy_breed_milk" text="SỮA TRONG BỒN" />
+        <text name="ft_dairy_breed_unknown" text="không rõ" />
+        <text name="ft_dairy_breed_waiting_server" text="Đang chờ máy chủ" />
+        <text name="ft_dairy_breed_waiting_farm" text="Đang chờ nông trại người chơi" />
+        <text name="ft_dairy_breed_route_unavailable" text="Tuyến bồn không khả dụng" />
+        <text name="ft_dairy_breed_filltype_unresolved" text="Không nhận ra loại sản phẩm" />
+        <text name="ft_dairy_breed_storage_missing" text="Không có kho nội bộ" />
+        <text name="ft_dairy_breed_snapshot_invalid" text="Ảnh chụp không hợp lệ" />
+        <text name="ft_dairy_breed_herd_unresolved" text="Không đọc được đàn" />
+        <text name="ft_dairy_breed_update_required" text="Cần cập nhật" />
+        <text name="ft_dairy_breed_head" text="%d con" />
+        <text name="ft_dairy_breed_litres" text="%d L" />
+        <text name="ft_dairy_breed_no_milk" text="không có sữa lưu" />
+        <text name="ft_dairy_breed_source_standard" text="đếm tiêu chuẩn" />
+        <text name="ft_dairy_breed_source_rl" text="đếm Realistic Livestock" />
+        <text name="ft_dairy_breed_waiting_farm_hint" text="Máy tính bảng chưa xác minh được nông trại của bạn. Thẻ chuồng sẽ ẩn cho đến khi xác minh được." />
+        <text name="ft_dairy_breed_waiting_server_hint" text="Máy chủ chưa gửi hồ sơ giống của nông trại này. Thẻ chuồng sẽ ẩn cho đến khi nhận được." />
+        <text name="ft_dairy_breed_help_title" text="HỒ SƠ GIỐNG" />
+        <text name="ft_dairy_breed_help_body" text="Đàn hiện tại đếm các con vật cho sữa trong chuồng.&#10;Sữa trong bồn theo dõi sữa đã lưu theo giống đã tạo ra&#10;nó. Đàn mới bên cạnh sữa cũ là bình thường. Sữa không rõ&#10;có từ trước khi ghi nhận hoặc vào theo đường không chứng&#10;minh được. Không giống nào được đánh giá ở đây." />
     </texts>
 
 


### PR DESCRIPTION
## Summary
- Farm Tablet Dairy app shows this farm's herd-now and milk-in-tank breed records.
- Farm id is the strict local farm only. It does not fall back to farm 1.
- Unknown milk stays a named row. Esc barn-card two-tall layout is not in this pull request.

## Test plan
- [ ] Open the Farm Tablet Dairy app on a farm with a barn.
- [ ] Confirm herd and tank breed rows for this farm only.
- [ ] Confirm a missing player farm paints waiting, not farm 1.