### PR TITLE
Group Farm Tablet owned-field lists by helper GPS outline

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK, Akita83</author>
-    <version>2.6.0.9</version>
+    <version>2.6.0.10</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/apps/NotesApp.lua
+++ b/src/apps/NotesApp.lua
@@ -46,6 +46,10 @@ end
 
 -- ── Owned field helper ───────────────────────────────────
 
+-- BUILD 19:23 (George CLOSED DESIGN 19:12): the picker lists owned FARMLAND ids (the id space
+-- the Soil merge keys use; Field:getId() is no longer mixed in) grouped into GPS-outline
+-- blocks through the mission bridge, each entry the text the label shows ("86" or "86-87").
+-- Soil absent = one entry per farmland id. Only farmlands that carry a field are listed.
 local function notes_getOwnedFieldNums()
     local result = {}
     if not g_localPlayer or not g_farmlandManager or not g_fieldManager then
@@ -54,16 +58,38 @@ local function notes_getOwnedFieldNums()
     local farmId = g_localPlayer.farmId
     if not farmId then return result end
     local farmlandIds = g_farmlandManager:getOwnedFarmlandIdsByFarmId(farmId)
+    local ids = {}
     for _, farmlandId in ipairs(farmlandIds) do
         local field = g_fieldManager.farmlandIdFieldMapping[farmlandId]
         if field then
-            local fid = field:getId()
-            if fid then
-                table.insert(result, fid)
-            end
+            ids[#ids + 1] = farmlandId
         end
     end
-    table.sort(result)
+    table.sort(ids)
+    local merge = nil
+    if g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil then
+        merge = g_currentMission.RfPdaSoilMerge
+    end
+    local groups = nil
+    if type(merge) == "table" and type(merge.buildGroups) == "function" and #ids > 1 then
+        local ok, built = pcall(merge.buildGroups, ids)
+        if ok and type(built) == "table" then groups = built end
+    end
+    if groups == nil then
+        for _, id in ipairs(ids) do
+            result[#result + 1] = tostring(id)
+        end
+        return result
+    end
+    for _, g in ipairs(groups) do
+        local members = g.memberIds or { g.fieldId }
+        local text = nil
+        if #members > 1 and type(merge.shortLabel) == "function" then
+            local ok, t = pcall(merge.shortLabel, members)
+            if ok and type(t) == "string" then text = t end
+        end
+        result[#result + 1] = text or tostring(g.fieldId)
+    end
     return result
 end
 

--- a/src/apps/SoilFertilizerApp.lua
+++ b/src/apps/SoilFertilizerApp.lua
@@ -62,7 +62,9 @@ FarmTabletUI:registerDrawer(FT.APP.FIELD_SENTRY, function(self)
 
     local data   = self.system.data
     local farmId  = data:getPlayerFarmId()
-    local fields  = data:getOwnedFields(farmId)
+    -- BUILD 19:23: FieldSentry stays per farmland id (raw): the sleep / meadow toggles are
+    -- keyed by the real farmland, never by a GPS-outline block.
+    local fields  = data:getOwnedFields(farmId, true)
     local isAdmin = (FS.isPlayerAdmin ~= nil) and (FS.isPlayerAdmin() == true)
 
     -- Summary count (asleep = simulation disabled for any reason).

--- a/src/utils/DataProvider.lua
+++ b/src/utils/DataProvider.lua
@@ -684,8 +684,29 @@ end
 
 -- Each Farmland links to ONE Field via farmland.field (set by FieldManager).
 -- Crop/growth state must be queried via FieldState:update(cx, cz), not from field directly.
-function FT_DataProvider:getOwnedFields(farmId)
-    return self:_cached("fields_"..farmId, 4000, function()
+--- BUILD 19:23 (George CLOSED DESIGN 19:12): the Soil list-row merge module on the mission
+--- bridge (Soil attaches it next to soilFertilityManager; getfenv(0) does not cross mods).
+--- nil when Soil is absent, and then the rows below stay per farmland id.
+local function _ftSoilMerge()
+    if g_currentMission == nil or g_currentMission.soilFertilityManager == nil then
+        return nil
+    end
+    local merge = g_currentMission.RfPdaSoilMerge
+    if type(merge) ~= "table" or type(merge.buildGroups) ~= "function" then
+        return nil
+    end
+    return merge
+end
+
+--- Owned fields. BUILD 19:23: one row per GPS-outline block (Montana 86 and 87 = one row
+--- { id = lead farmland, area = sum of member areas, memberIds = sorted ids }, crop / state /
+--- phase from the lead); every row carries memberIds, singles as { id }. raw = true keeps the
+--- per-farmland list (FieldSentry sleep / meadow toggles are per farmland id). Same 4000 ms
+--- cache, one key per mode; invalidate() drops both.
+---@param farmId number
+---@param raw boolean|nil true = per farmland id, no grouping
+function FT_DataProvider:getOwnedFields(farmId, raw)
+    return self:_cached("fields_"..farmId..(raw and "_raw" or ""), 4000, function()
         local out = {}
         if not g_farmlandManager then return out end
 
@@ -740,7 +761,47 @@ function FT_DataProvider:getOwnedFields(farmId)
         end
 
         table.sort(out, function(a, b) return a.id < b.id end)
-        return out
+        for _, f in ipairs(out) do
+            f.memberIds = { f.id }
+        end
+        if raw then
+            return out
+        end
+        local merge = _ftSoilMerge()
+        if merge == nil or #out < 2 then
+            return out
+        end
+        local byId, ids = {}, {}
+        for _, f in ipairs(out) do
+            byId[f.id] = f
+            ids[#ids + 1] = f.id
+        end
+        local ok, groups = pcall(merge.buildGroups, ids)
+        if not ok or type(groups) ~= "table" then
+            return out
+        end
+        local grouped = {}
+        for _, g in ipairs(groups) do
+            local lead = byId[g.id or g.fieldId]
+            local members = g.memberIds or { g.fieldId }
+            if lead ~= nil then
+                local row = {
+                    id = lead.id, cropName = lead.cropName, stateName = lead.stateName,
+                    stateColor = lead.stateColor, phase = lead.phase, area = 0, memberIds = {},
+                }
+                for _, mid in ipairs(members) do
+                    local m = byId[mid]
+                    if m ~= nil then
+                        row.area = row.area + (tonumber(m.area) or 0)
+                        row.memberIds[#row.memberIds + 1] = mid
+                    end
+                end
+                table.sort(row.memberIds)
+                grouped[#grouped + 1] = row
+            end
+        end
+        table.sort(grouped, function(a, b) return a.id < b.id end)
+        return grouped
     end)
 end
 


### PR DESCRIPTION
## Summary
- Farm Tablet owned-field pickers use Soil's GPS-outline groups when Soil is present, so joined helper outlines show as one field.
- FieldSentry sleep/meadow toggles stay per farmland (ungrouped path).
- Notes field picker uses the same farmland ids as Soil.

## Test plan
- [ ] Full start or hot-reload Lua.
- [ ] Field Status and other owned-field apps show joined outlines (Field 86-87) after Soil has walked them.
- [ ] FieldSentry still lists each farmland id.
- [ ] Notes picker offers the joined label for a GPS block.
