### PR TITLE
Farm Tablet glance leftover: card hairlines and screen spacing

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="106">
     <author>TisonK, Akita83</author>
-    <version>2.6.0.10</version>
+    <version>2.6.0.11</version>
     <modName>FS25_FarmTablet</modName>
     <title>
         <en>Farm Tablet</en>

--- a/src/FarmTabletUI.lua
+++ b/src/FarmTabletUI.lua
@@ -1225,15 +1225,30 @@ end
 function FarmTabletUI:_drawNavCluster(sx, barY, barH, accent, starActive)
     local r = self.r
     local homeOn, backOn = self:_navState()
-    local btnH  = FT.py(20)
+    -- Home / Back / Star are boxed squares in the springboard tile / title-icon
+    -- treatment: charcoal BG_CARD fill with a white hairline. The hit rects on
+    -- _homeBtn / _backBtn / _starBtn, the enabled dimming and the _onMouse skip
+    -- of disabled controls are unchanged.
+    local btnW  = FT.px(24)
+    local btnH  = FT.py(24)
+    local gap   = FT.px(6)
     local glyph = {0.92, 0.95, 0.99, 0.95}
     local hbY   = barY + (barH - btnH) / 2
+    local hairH = math.max(FT.py(1), 0.0009)
+    local hairW = math.max(FT.px(1), 0.0006)
+    local function navBox(bx, enabled)
+        r:rect(bx, hbY, btnW, btnH, dimmed(FT.C.BG_CARD, enabled))
+        local line = dimmed({1, 1, 1, 0.22}, enabled)
+        r:rect(bx, hbY + btnH - hairH, btnW, hairH, line)   -- top
+        r:rect(bx, hbY, btnW, hairH, line)                  -- bottom
+        r:rect(bx, hbY, hairW, btnH, line)                  -- left
+        r:rect(bx + btnW - hairW, hbY, hairW, btnH, line)   -- right
+    end
 
-    -- HOME — a little house
-    local hbW = FT.px(34)
-    local hbX = sx + FT.px(6)
-    r:rect(hbX, hbY, hbW, btnH, dimmed({1,1,1,0.08}, homeOn))
-    local cx           = hbX + hbW / 2
+    -- HOME - a little house
+    local hbX = sx + gap
+    navBox(hbX, homeOn)
+    local cx           = hbX + btnW / 2
     local bodyW, bodyH = FT.px(13), FT.py(7)
     local roofW, roofH = FT.px(18), FT.py(6)
     local houseBottom  = hbY + (btnH - (bodyH + roofH)) / 2
@@ -1241,26 +1256,25 @@ function FarmTabletUI:_drawNavCluster(sx, barY, barH, accent, starActive)
     r:rect(cx - FT.px(2), houseBottom, FT.px(4), FT.py(4.5),
            dimmed({accent[1], accent[2], accent[3], 1}, homeOn))                                                  -- door
     drawTriUp(r, cx, houseBottom + bodyH, roofW, roofH, dimmed(glyph, homeOn))                                    -- roof
-    self._homeBtn = { x = hbX, y = barY, w = hbW, h = barH, enabled = homeOn }
+    self._homeBtn = { x = hbX, y = barY, w = btnW, h = barH, enabled = homeOn }
 
-    -- BACK — a left-pointing arrow
-    local bbW = FT.px(30)
-    local bbX = hbX + hbW + FT.px(6)
-    r:rect(bbX, hbY, bbW, btnH, dimmed({1,1,1,0.06}, backOn))
+    -- BACK - a left-pointing arrow
+    local bbX = hbX + btnW + gap
+    navBox(bbX, backOn)
     local acy = hbY + btnH / 2
     local headW, headH, shaftH = FT.px(7), FT.py(12), FT.py(3)
-    local tipX = bbX + FT.px(8)
+    local tipX = bbX + FT.px(5)
     drawTriLeft(r, tipX, acy, headW, headH, dimmed(glyph, backOn))                          -- arrowhead
     r:rect(tipX + headW * 0.5, acy - shaftH / 2, FT.px(10), shaftH, dimmed(glyph, backOn))  -- shaft
-    self._backBtn = { x = bbX, y = barY, w = bbW, h = barH, enabled = backOn }
+    self._backBtn = { x = bbX, y = barY, w = btnW, h = barH, enabled = backOn }
 
     -- STAR - opens / toggles the favourites page. Always available.
-    local sbW = FT.px(30)
-    local sbX = bbX + bbW + FT.px(6)
-    self:_drawStarGlyph(sbX, hbY, sbW, btnH, starActive == true)
-    self._starBtn = { x = sbX, y = barY, w = sbW, h = barH, enabled = true }
+    local sbX = bbX + btnW + gap
+    navBox(sbX, true)
+    self:_drawStarGlyph(sbX, hbY, btnW, btnH, starActive == true)
+    self._starBtn = { x = sbX, y = barY, w = btnW, h = barH, enabled = true }
 
-    return sbX + sbW
+    return sbX + btnW
 end
 
 function FarmTabletUI:_drawAppView()

--- a/src/apps/AnimalHusbandryApp.lua
+++ b/src/apps/AnimalHusbandryApp.lua
@@ -36,7 +36,7 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
 
     local scrollY = self:getContentScrollY()
     local y = startY + scrollY
-    local pad = FT.px(8)
+    local pad = FT.px(FT.SP.MD)   -- inner card pad (14), so the pens read as cards
 
     local function barColor(pct)
         if pct >= 60 then return FT.C.POSITIVE
@@ -69,10 +69,10 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
             metrics[#metrics + 1] = { label = FT.l10nAuto("STRAW/CLEAN"), pct = pen.cleanPct }
         end
 
-        local headerH = FT.py(22)
+        local headerH = FT.py(24)
         local metricH = #metrics * FT.py(20)
-        local cardH = headerH + metricH + FT.py(10)
-        if #metrics == 0 then cardH = FT.py(30) end
+        local cardH = headerH + metricH + FT.py(12)
+        if #metrics == 0 then cardH = FT.py(32) end
         local cardBottom = y - cardH
 
         self.r:appRect(x - FT.px(4), cardBottom, cw + FT.px(8), cardH, FT.C.BG_CARD)
@@ -83,7 +83,7 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
         else
             header = header .. "  (" .. FT.l10n("ft_common_empty_lower", "empty") .. ")"
         end
-        self.r:appText(x + pad, y - FT.py(6), FT.FONT.BODY, header, RenderText.ALIGN_LEFT,
+        self.r:appText(x + pad, y - FT.py(9), FT.FONT.BODY, header, RenderText.ALIGN_LEFT,
             pen.numAnimals > 0 and FT.C.TEXT_BRIGHT or FT.C.TEXT_DIM)
 
         local rowY = y - headerH
@@ -91,8 +91,8 @@ FarmTabletUI:registerDrawer(FT.APP.ANIMALS, function(self)
             rowY = drawMetric(rowY, m.label, m.pct)
         end
 
-        -- Pin to pre-sized card bottom, then gap before the next pen.
-        y = cardBottom - FT.py(8)
+        -- Pin to pre-sized card bottom, then a card gap (14) before the next pen.
+        y = cardBottom - FT.py(FT.SP.MD)
     end
 
     self:setContentHeight(startY - y + scrollY)

--- a/src/apps/DairyApp.lua
+++ b/src/apps/DairyApp.lua
@@ -13,6 +13,46 @@ local function _dairyMgr()
         or getfenv(0)["g_dairyCoreManager"]
 end
 
+-- Human barn name for the card title. The same ladder as the Esc guest
+-- (DairyRfPdaGuest.barnLabel): a real name carried on the row wins, then the
+-- placeable's own getName() / nameCustom / nameL10n / store name, and only then
+-- the "Barn <id>" fallback. Tablet app only; the Esc guest is untouched.
+local function barnLabel(row)
+    if row == nil then
+        return FT.l10nFormat("ft_dairy_barn_id", "Barn %s", "?")
+    end
+    local human = row.nameCustom or row.displayName or row.barnName or row.name
+    if type(human) == "string" and human ~= "" then
+        return human
+    end
+    local barnId = row.barnId
+    local ps = (g_currentMission ~= nil) and g_currentMission.placeableSystem or nil
+    if barnId ~= nil and ps ~= nil and type(ps.getPlaceableByUniqueId) == "function" then
+        local ok, placeable = pcall(function() return ps:getPlaceableByUniqueId(barnId) end)
+        if ok and placeable ~= nil then
+            if type(placeable.getName) == "function" then
+                local okName, n = pcall(function() return placeable:getName() end)
+                if okName and type(n) == "string" and n ~= "" then return n end
+            end
+            if type(placeable.nameCustom) == "string" and placeable.nameCustom ~= "" then
+                return placeable.nameCustom
+            end
+            if type(placeable.nameL10n) == "string" and placeable.nameL10n ~= "" then
+                return placeable.nameL10n
+            end
+            local si = placeable.storeItem
+            if si ~= nil and type(si.name) == "string" and si.name ~= "" then
+                return si.name
+            end
+        end
+    end
+    local id = tostring(barnId or "?")
+    if #id > 24 then
+        id = id:sub(1, 22) .. "..."
+    end
+    return FT.l10nFormat("ft_dairy_barn_id", "Barn %s", id)
+end
+
 local function healthColor(pct)
     local p = tonumber(pct) or 0
     if p >= 85 then return FT.C.POSITIVE
@@ -390,7 +430,7 @@ FarmTabletUI:registerDrawer(FT.APP.DAIRY, function(self)
 
         self.r:appRect(x - FT.px(4), cardBottom, cw + FT.px(8), cardH, FT.C.BG_CARD)
 
-        local header = FT.l10nFormat("ft_dairy_barn_id", "Barn %s", tostring(row.barnId or "?"))
+        local header = barnLabel(row)
         self.r:appText(x + pad, y - FT.py(6), FT.FONT.BODY, header,
             RenderText.ALIGN_LEFT, FT.C.TEXT_BRIGHT)
 

--- a/src/apps/FieldStatusApp.lua
+++ b/src/apps/FieldStatusApp.lua
@@ -55,7 +55,7 @@ FarmTabletUI:registerDrawer(FT.APP.FIELDS, function(self)
         end
     end
 
-    local y  = startY - FT.py(2) + scrollY
+    local y  = startY - FT.py(12) + scrollY   -- breath under the header rule before the badges
     local bx = x
     if countReady   > 0 then bx = bx + self.r:badge(bx, y, countReady.." "..ftText("ft_fields_badge_ready", "READY"), FT.C.BTN_PRIMARY)   + FT.px(4) end
     if countGrowing > 0 then bx = bx + self.r:badge(bx, y, countGrowing.." "..ftText("ft_fields_badge_grow", "GROW"),  FT.C.BTN_NEUTRAL)   + FT.px(4) end

--- a/src/apps/FinancialCockpitApp.lua
+++ b/src/apps/FinancialCockpitApp.lua
@@ -242,6 +242,22 @@ local function _readRweSignal()
     return { present = true, event = ev, intensity = intensity }
 end
 
+-- getActiveEvent() hands back a table ({ name, intensity, category, remainingMs }
+-- from RandomWorldEvents, or the event definition from its category API), so the
+-- signal row reads a display field and never tostring()s the table.
+local function _rweEventLabel(ev)
+    local raw
+    if type(ev) == "table" then
+        raw = ev.title or ev.name or ev.displayName or ev.id or ev.eventId
+    else
+        raw = ev
+    end
+    if raw == nil or raw == "" then return "?" end
+    -- "field_mice_invasion" -> "Field mice invasion" (same rule as the RWE app).
+    local label = tostring(raw):gsub("_", " ")
+    return label:sub(1, 1):upper() .. label:sub(2)
+end
+
 local function _flowGaps(flows)
     -- Dollar-flow gaps that force PARTIAL on derived vitals / forecast.
     local gaps = {}
@@ -1186,7 +1202,7 @@ local function _drawFlowsPocket(self, snap, AC)
     end
     if snap.rwe and snap.rwe.event then
         y = self:drawRow(y, _T("ft_fc_signal_rwe", "World event"),
-            tostring(snap.rwe.event), nil, FT.C.TEXT_ACCENT)
+            _rweEventLabel(snap.rwe.event), nil, FT.C.TEXT_ACCENT)
     end
 
     self:setContentHeight(startY - y + scrollY)

--- a/src/apps/OrganicApp.lua
+++ b/src/apps/OrganicApp.lua
@@ -263,6 +263,9 @@ FarmTabletUI:registerDrawer(FT.APP.ORGANIC, function(self)
             self.r:appText(x, y - FT.py(4), FT.FONT.SMALL,
                 "No compost batches. Start one from the SoilFertilizer console.",
                 RenderText.ALIGN_LEFT, FT.C.MUTED)
+            -- Advance past the line (same step as the not-available branch) so the
+            -- LIVESTOCK header does not land on top of it.
+            y = y - FT.py(22)
         else
             for _, b in ipairs(rows) do
                 local state = b.ready

--- a/src/utils/Renderer.lua
+++ b/src/utils/Renderer.lua
@@ -123,6 +123,11 @@ end
 --- callers must do that themselves if they want click handling.
 function FT_Renderer:button(x, y, w, h, label, color, meta)
     local ov = self:appRect(x, y, w, h, color or FT.C.BTN_NEUTRAL)
+    -- Boxed read on any background: a light top edge and a dark bottom edge on
+    -- the shared fill (existing tokens only, no new palette).
+    local edge = math.max(FT.py(1), 0.0009)
+    self:appRect(x, y + h - edge, w, edge, {1, 1, 1, 0.12})
+    self:appRect(x, y, w, edge, {0, 0, 0, 0.35})
     local txt = (FT.l10nAuto ~= nil and FT.l10nAuto(label) or tostring(label or ""))
     local len = string.len(tostring(txt or ""))
     local fontSize = FT.FONT.SMALL
@@ -167,17 +172,25 @@ function FT_Renderer:progressBar(x, y, w, value, maxVal, barColor)
     return y - h - FT.py(2)
 end
 
---- Draws a section heading with a coloured left accent bar.
+--- Draws a section heading: a boxed header row (BG_CARD) with the brand accent
+--- bar on its left edge. The box sits inside the 18px the caller reserves, so the
+--- y-cursor contract (drawSection returns y - FT.py(18)) is unchanged.
 function FT_Renderer:sectionHeader(x, y, contentW, label)
-    self:appRect(x, y - FT.py(2), FT.px(3), FT.py(13), FT.C.BRAND)
-    self:appText(x + FT.px(8), y, FT.FONT.SMALL, label,
+    local boxH = FT.py(16)
+    local boxY = y - FT.py(3)
+    self:appRect(x, boxY, contentW, boxH, FT.C.BG_CARD)
+    self:appRect(x, boxY, FT.px(3), boxH, FT.C.BRAND)
+    self:appText(x + FT.px(10), y, FT.FONT.SMALL, label,
         RenderText.ALIGN_LEFT, FT.C.TEXT_ACCENT)
 end
 
---- Draws a label/value row with the label left-aligned and value right-aligned.
---- Pass nil for value to draw the label only.
+--- Draws a label/value row as a boxed card (BG_CARD) with an inner pad: the label
+--- sits left-aligned and the value right-aligned inside the box, so the two read
+--- as one grouped line. Pass nil for value to draw the label only.
+--- The box is 19px of the 22px row pitch (FT.SP.ROW), leaving a 3px seam.
 function FT_Renderer:row(x, y, contentW, label, value, labelColor, valueColor)
-    local padX = FT.px(14)
+    local padX = FT.px(FT.SP.MD)
+    self:appRect(x, y - FT.py(6), contentW, FT.py(19), FT.C.BG_CARD)
     self:appText(x + padX, y, FT.FONT.BODY, label,
         RenderText.ALIGN_LEFT, labelColor or FT.C.TEXT_NORMAL)
     if value ~= nil then


### PR DESCRIPTION
## Summary
- Farm Tablet glance leftover: charcoal card hairlines, Dairy and money screens, and a little space under the Fields header.
- Owned-field GPS grouping already sits on development from the earlier lists work. This pull request does not change that rule.

## Test plan
- [ ] Full start. Field Status, Dairy, and money screens still open.
- [ ] Fields header is not kissing the badges.
- [ ] FieldSentry stays per farmland number.
